### PR TITLE
Creates a graph from the data in the vault and metadataCache

### DIFF
--- a/sigma/src/classes/sigma.classes.edge.js
+++ b/sigma/src/classes/sigma.classes.edge.js
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2020 Obsidian Better Graph View
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Class for an edge in a graph.
+ * @author bekawestberg@gmail.com (Beka Westberg)
+ */
+'use strict';
+
+
+export class Edge {
+  /**
+   * Constructs an edge with the folowing properties.
+   * @param {string} id The identifier for the edge.
+   * @param {string} sourceId The identifier of the source node.
+   * @param {string} targetId The identifier of the target node.
+   * @param {number} size The size of the edge.
+   * @param {string} color The color of the edge as a '#rgb' or '#rrggbb' string.
+   */
+  constructor(id, sourceId, targetId, size, color) {
+    this.id = id;
+    this.source = sourceId;
+    this.target = targetId;
+    this.size = size;
+    this.color = color;
+  }
+}

--- a/sigma/src/classes/sigma.classes.node.js
+++ b/sigma/src/classes/sigma.classes.node.js
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2020 Obsidian Better Graph View
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Class for a node in a graph.
+ * @author bekawestberg@gmail.com (Beka Westberg)
+ */
+'use strict';
+
+
+export class Node {
+  /**
+   * Constructs a node with the following properties.
+   * @param {string} id The identifier for the node.
+   * @param {string} label The display text for the node.
+   * @param {number} x The x position of the node.
+   * @param {number} y The y position of the node.
+   * @param {number} size The size of the node.
+   * @param {string} color The color of the node as a '#rgb' or '#rrggbb' string.
+   */
+  constructor(id, label, x, y, size, color) {
+    this.id = id;
+    this.label = label;
+    this.x = x;
+    this.y = y;
+    this.size = size;
+    this.color = color;
+  }
+}

--- a/src/graph-builders/i_graphbuilder.js
+++ b/src/graph-builders/i_graphbuilder.js
@@ -12,7 +12,7 @@
 'use strict';
 
 
-import {Vault} from "obsidian";
+import {Vault, MetadataCache} from "obsidian";
 import {Node} from "../../sigma/src/classes/sigma.classes.node";
 import {Edge} from "../../sigma/src/classes/sigma.classes.edge";
 
@@ -25,11 +25,13 @@ import {Edge} from "../../sigma/src/classes/sigma.classes.edge";
 export class GraphBuilder {
   /**
    * Generates a graph for the given vault.
-   * @param {Vault} vault The vault to use to generate the graph.
+   * @param {Vault} vault The vault to used to generate the graph.
+   * @param {MetadataCache} metadataCache The metadata cache used to generate
+   *     the graph.
    * @return {{nodes: !Array<Node>, edges: !Array<Edge>}} A valid graph which
    *     sigma.js will accept.
    */
-  generateGraph(vault) {
+  generateGraph(vault, metadataCache) {
     return {
       nodes: [],
       edges: [],

--- a/src/graph-builders/i_graphbuilder.js
+++ b/src/graph-builders/i_graphbuilder.js
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2020 Obsidian Better Graph View
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Interface for a graph builder, which is an object that builds
+ *     a graph that sigma.js will accept.
+ * @author bekawestberg@gmail.com (Beka Westberg)
+ */
+'use strict';
+
+
+import {Vault} from "obsidian";
+import {Node} from "../../sigma/src/classes/sigma.classes.node";
+import {Edge} from "../../sigma/src/classes/sigma.classes.edge";
+
+
+/**
+ * Interface for a graph builder, which is an object that builds a graph that
+ * sigma.js will accept.
+ * @interface
+ */
+function GraphBuilder() {}
+
+/**
+ * Generates a graph for the given vault.
+ * @param {Vault} vault The vault to use to generate the graph.
+ * @return {{nodes: !Array<Node>, edges: !Array<Edge>}} A valid graph which
+ *     sigma.js will accept.
+ */
+GraphBuilder.prototype.generateGraph = function (vault) {
+  return {
+    nodes: [],
+    edges: [],
+  }
+};

--- a/src/graph-builders/i_graphbuilder.js
+++ b/src/graph-builders/i_graphbuilder.js
@@ -22,17 +22,17 @@ import {Edge} from "../../sigma/src/classes/sigma.classes.edge";
  * sigma.js will accept.
  * @interface
  */
-function GraphBuilder() {}
-
-/**
- * Generates a graph for the given vault.
- * @param {Vault} vault The vault to use to generate the graph.
- * @return {{nodes: !Array<Node>, edges: !Array<Edge>}} A valid graph which
- *     sigma.js will accept.
- */
-GraphBuilder.prototype.generateGraph = function (vault) {
-  return {
-    nodes: [],
-    edges: [],
+export class GraphBuilder {
+  /**
+   * Generates a graph for the given vault.
+   * @param {Vault} vault The vault to use to generate the graph.
+   * @return {{nodes: !Array<Node>, edges: !Array<Edge>}} A valid graph which
+   *     sigma.js will accept.
+   */
+  generateGraph(vault) {
+    return {
+      nodes: [],
+      edges: [],
+    }
   }
-};
+}

--- a/src/graph-builders/simple.js
+++ b/src/graph-builders/simple.js
@@ -51,7 +51,6 @@ export class SimpleGraphBuilder extends GraphBuilder {
           '#666'
       ));
     });
-    console.log(g.nodes);
 
     // Add links as edges and non-existing files as nodes.
     files.forEach((file) => {
@@ -65,14 +64,21 @@ export class SimpleGraphBuilder extends GraphBuilder {
       cache.links.forEach((ref) => {
         const refExists = g.nodes.some((elem) => elem.id == ref.link);
         if (!refExists) {
-          return;
+          g.nodes.push(new Node(
+              ref.link,
+              ref.link,
+              numFiles * 10 * Math.random(),
+              numFiles * 10 * Math.random(),
+              1,
+              '#ccc'
+          ));
         }
 
         g.edges.push(new Edge(
             fileId + ' to ' + ref.link,
             fileId,
             ref.link,
-            10,
+            1,
             '#ccc',
         ));
       })

--- a/src/graph-builders/simple.js
+++ b/src/graph-builders/simple.js
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2020 Obsidian Better Graph View
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Class for the better graph view.
+ * @author bekawestberg@gmail.com (Beka Westberg)
+ */
+'use strict';
+
+
+import {Vault, MetadataCache} from "obsidian";
+import {GraphBuilder} from "./i_graphbuilder";
+import {Node} from "../../sigma/src/classes/sigma.classes.node";
+import {Edge} from "../../sigma/src/classes/sigma.classes.edge";
+
+
+export class SimpleGraphBuilder extends GraphBuilder {
+  /**
+   * Generates a simple graph for the given vault. Looks very similar to the
+   * default obsidian graph.
+   * @param {Vault} vault The vault to use to generate the graph.
+   * @param {MetadataCache} metadataCache The metadata cache used to generate
+   *     the graph.
+   * @return {{nodes: !Array<Node>, edges: !Array<Edge>}} A simple graph very
+   *     similar to the default obsidian graph.
+   */
+  generateGraph(vault, metadataCache) {
+    const g = {
+      nodes: [],
+      edges: [],
+    };
+
+    const files = vault.getMarkdownFiles();
+    if (!files) {
+      return;
+    }
+    const numFiles = files.length;
+
+    // Add existing files as nodes.
+    files.forEach((file) => {
+      const id = metadataCache.fileToLinktext(file, file.path);
+      g.nodes.push(new Node(
+          id,
+          file.basename,
+          numFiles * 10 * Math.random(),
+          numFiles * 10 * Math.random(),
+          1,
+          '#666'
+      ));
+    });
+    console.log(g.nodes);
+
+    // Add links as edges and non-existing files as nodes.
+    files.forEach((file) => {
+      const fileId = metadataCache.fileToLinktext(file, file.path);
+
+      const cache = metadataCache.getFileCache(file);
+      if (!cache.links) {
+        return;
+      }
+
+      cache.links.forEach((ref) => {
+        const refExists = g.nodes.some((elem) => elem.id == ref.link);
+        if (!refExists) {
+          return;
+        }
+
+        g.edges.push(new Edge(
+            fileId + ' to ' + ref.link,
+            fileId,
+            ref.link,
+            10,
+            '#ccc',
+        ));
+      })
+    });
+
+    return g;
+  }
+}

--- a/src/view.js
+++ b/src/view.js
@@ -90,26 +90,27 @@ export default class BetterGraphView extends ItemView {
    * @return {Promise<void>} A promise to create the view.
    */
   async onOpen() {
+    const {vault, metadataCache} = this.app;
+
     const div = document.createElement('div');
     div.setAttribute('id', 'graph-container');
     this.contentEl.appendChild(div);
 
     const graphBuilder = new SimpleGraphBuilder();
     const s = new sigma({
-      graph: graphBuilder.generateGraph(this.app.vault, this.app.metadataCache),
+      graph: graphBuilder.generateGraph(vault, metadataCache),
       renderer: {
         container: div,
         type: 'canvas',
       }
     });
-    const atlasObj = s.startForceAtlas2(
-        {
-          worker: true,
-          barnesHutOptimize: false,
-          scalingRatio: .025,
-          gravity: 1,
-        }
-    );
+
+    const atlasObj = s.startForceAtlas2({
+      worker: true,
+      barnesHutOptimize: false,
+      scalingRatio: .025,
+      gravity: 1,
+    });
 
     const dragListener = sigma.plugins.dragNodes(s, s.renderers[0]);
     dragListener.bind('startdrag', function(event) {

--- a/src/view.js
+++ b/src/view.js
@@ -12,8 +12,9 @@
 
 
 // Obsidian imports
-import { ItemView, WorkspaceLeaf} from 'obsidian';
-import { VIEW_TYPE_BETTER_GRAPH, BETTER_GRAPH_TITLE } from "./constants";
+import {ItemView, WorkspaceLeaf, Vault} from 'obsidian';
+import {VIEW_TYPE_BETTER_GRAPH} from "./constants";
+import {SimpleGraphBuilder} from "./graph-builders/simple";
 
 // Sigma imports
 import '../sigma/src/sigma.core';
@@ -93,58 +94,21 @@ export default class BetterGraphView extends ItemView {
     div.setAttribute('id', 'graph-container');
     this.contentEl.appendChild(div);
 
-    const N = 100,
-        E = 100;
-
-    const g = {
-      nodes: [],
-      edges: [],
-    };
-
-    for (let i = 0; i < N; i++) {
-      g.nodes.push({
-        id: 'n' + i,
-        label: 'Node' + i,
-        x: 100 * Math.cos(2 * i * Math.PI / N),
-        y: 100 * Math.sin(2 * i * Math.PI / N),
-        size: 1,
-        color: '#666'
-
-      })
-    }
-    for (let i = 1; i < N; i++) {
-      g.edges.push({
-        id: 'e' + i,
-        source: 'n' + (i-1),
-        target: 'n' + i,
-        size: Math.random(),
-        colour: '#ccc'
-      })
-    }
-
+    const graphBuilder = new SimpleGraphBuilder();
     const s = new sigma({
-      graph: g,
+      graph: graphBuilder.generateGraph(this.app.vault, this.app.metadataCache),
       renderer: {
         container: div,
         type: 'canvas',
       }
     });
     const atlasObj = s.startForceAtlas2(
-      {
-        linLogMode: false,
-        outboundAttractionDistribution: false,
-        adjustSizes: false,
-        edgeWeightInfluence: 0,
-        scalingRatio: 1,
-        strongGravityMode: false,
-        gravity: 1,
-        barnesHutOptimize: true,
-        barnesHutTheta: 0.5,
-        slowDown: 10,
-        startingIterations: 1,
-        iterationsPerRender: 1,
-        worker: false
-      }
+        {
+          worker: true,
+          barnesHutOptimize: false,
+          scalingRatio: .025,
+          gravity: 1,
+        }
     );
 
     const dragListener = sigma.plugins.dragNodes(s, s.renderers[0]);
@@ -153,6 +117,6 @@ export default class BetterGraphView extends ItemView {
     });
     dragListener.bind('dragend', function (event) {
       atlasObj.supervisor.setDraggingNode(null);
-    })
+    });
   }
 }


### PR DESCRIPTION
### Description

Added a GraphBuilder "abstract class" that defines the interface for an object that constructs a graph. These objects will define the nodes, the node names, and the edges between the nodes. In the future they may also provide settings so that you can toggle features of a graph builder on and off.

Also defines some other classes to go along with this like nodes and edges.

And I created a simple graph builder that mimics obsidian's default graph builder.

### Testing

Manually tested that the graphs from the simple graph builder and obsidian's graph builder match:
![Uncreated Nodes](https://user-images.githubusercontent.com/25440652/100030719-074ad600-2da9-11eb-93b7-e3ddf328764d.png)
![WholeGraphs](https://user-images.githubusercontent.com/25440652/100030724-087c0300-2da9-11eb-8818-b0daf392a410.png)
