### PR TITLE
Adds tags-centered graph builder

### DIFF
--- a/sigma/src/classes/sigma.classes.graph.js
+++ b/sigma/src/classes/sigma.classes.graph.js
@@ -448,8 +448,9 @@
         !this.nodesIndex[edge.target])
       throw 'The edge target must have an existing node id.';
 
-    if (this.edgesIndex[edge.id])
+    if (this.edgesIndex[edge.id]) {
       throw 'The edge "' + edge.id + '" already exists.';
+    }
 
     var k,
         validEdge = Object.create(null);

--- a/src/graph-builders/simple.js
+++ b/src/graph-builders/simple.js
@@ -151,6 +151,7 @@ export class SimpleGraphBuilder extends GraphBuilder {
    */
   addExistingFiles_(files, metadataCache) {
     const existingFileIds = new Set();
+    const edgeIds = new Set();
 
     // Create nodes.
     files.forEach((file) => {
@@ -177,8 +178,13 @@ export class SimpleGraphBuilder extends GraphBuilder {
         if (!existingFileIds.has(ref.link)) {
           return;
         }
+        const edgeId = fileId + ' to ' + ref.link;
+        if (edgeIds.has(edgeId)) {
+          return;
+        }
+        edgeIds.add(edgeId);
         this.graph_.addEdge(new Edge(
-            fileId + ' to ' + ref.link,
+            edgeId,
             fileId,
             ref.link,
             1,
@@ -202,6 +208,7 @@ export class SimpleGraphBuilder extends GraphBuilder {
     });
 
     const createdNonExistingIds = new Set();
+    const createdEdgeIds = new Set();
     files.forEach((file) => {
       const fileId = metadataCache.fileToLinktext(file, file.path);
       const cache = metadataCache.getFileCache(file);
@@ -226,8 +233,13 @@ export class SimpleGraphBuilder extends GraphBuilder {
           node.isNonExisting = true;
           this.graph_.addNode(node);
         }
+        const edgeId = fileId + ' to ' + ref.link;
+        if (createdEdgeIds.has(edgeId)) {
+          return;
+        }
+        createdEdgeIds.add(edgeId);
         this.graph_.addEdge(new Edge(
-            fileId + ' to ' + ref.link,
+            edgeId,
             fileId,
             ref.link,
             1,
@@ -316,6 +328,7 @@ export class SimpleGraphBuilder extends GraphBuilder {
    */
   addAttachments_(files, metadataCache) {
     const createdAttachmentIds = new Set();
+    const createdEdgeIds = new Set();
     files.forEach((file) => {
       const fileId = metadataCache.fileToLinktext(file, file.path);
       const cache = metadataCache.getFileCache(file);
@@ -338,8 +351,12 @@ export class SimpleGraphBuilder extends GraphBuilder {
           node.isAttachment = true;
           this.graph_.addNode(node);
         }
+        const edgeId = fileId + ' to ' + attachmentId;
+        if (createdEdgeIds.has(edgeId)) {
+          return;
+        }
+        createdEdgeIds.add(edgeId);
         this.graph_.addEdge(new Edge(
-           fileId + ' to ' + attachmentId,
            fileId,
            attachmentId,
            1,

--- a/src/graph-builders/tags.js
+++ b/src/graph-builders/tags.js
@@ -1,0 +1,129 @@
+/**
+ * @license
+ * Copyright 2020 Obsidian Better Graph View
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Class for a graph builder that shows connections between tags.
+ * @author bekawestberg@gmail.com (Beka Westberg)
+ */
+'use strict';
+
+
+import {GraphBuilder} from './i-graphbuilder';
+import {Node} from "../../sigma/src/classes/sigma.classes.node";
+import {Edge} from "../../sigma/src/classes/sigma.classes.edge";
+import {GraphBuilderRegistry} from "./graph-builders-registry";
+
+
+const NOTES = 'notes';
+const MULT = 5;
+
+export class TagsGraphBuilder extends GraphBuilder {
+  /**
+   * Returns the display name of this graph builder.
+   * @return {string} The display name of this graph builder.
+   */
+  getDisplayName() {
+    return 'Tags';
+  }
+
+  /**
+   * Returns the configuration of this graph builder.
+   * @return {!Array}
+   */
+  getConfig() {
+    return [
+      {
+        type: 'toggle',
+        id: NOTES,
+        displayText: 'Notes',
+        default: false,
+      },
+    ]
+  };
+
+  /**
+   * Generates a graph that shows the connections between tags. Tags are
+   * connected if they appear together.
+   * @param {!Map<string, *>} config The current configuration of the graph.
+   * @param {!Vault} vault The vault to use to generate the graph.
+   * @param {!MetadataCache} metadataCache The metadata cache used to generate
+   *     the graph.
+   */
+  generateGraph(config, vault, metadataCache) {
+    const files = vault.getMarkdownFiles();
+    if (!files) {
+      return;
+    }
+
+    this.addTags_(files, metadataCache);
+  }
+
+  /**
+   * Adds nodes representing tags to the graph, and connects them.
+   * @param {!Array<!TFile>} files All of the files in the vault.
+   * @param {!MetadataCache} metadataCache The metadata cache used to generate
+   *     the graph.
+   * @private
+   */
+  addTags_(files, metadataCache) {
+    const createdTagIds = new Set();
+    const createdEdgeIds = new Set();
+
+    files.forEach((file) => {
+      const cache = metadataCache.getFileCache(file);
+      if (!cache.tags) {
+        return;
+      }
+
+      // Create nodes.
+      cache.tags.forEach((tagCache) => {
+        if (!createdTagIds.has(tagCache.tag)) {
+          createdTagIds.add(tagCache.tag);
+          this.graph_.addNode(new Node(
+              tagCache.tag,
+              tagCache.tag,
+              MULT * Math.random(),
+              MULT * Math.random(),
+              1,
+              '#666'
+          ));
+        }
+      });
+
+      // Create edges.
+      cache.tags.forEach((tagCache1) => {
+        cache.tags.forEach((tagCache2) => {
+          if (tagCache1.tag == tagCache2.tag) {
+            return;
+          }
+          const edgeId1 = tagCache1.tag + ' to ' + tagCache2.tag;
+          const edgeId2 = tagCache2.tag + ' to ' + tagCache1.tag;
+          if (createdEdgeIds.has(edgeId1) || createdEdgeIds.has(edgeId2)) {
+            return;
+          }
+          createdEdgeIds.add(edgeId1);
+          createdEdgeIds.add(edgeId2);
+          this.graph_.addEdge(new Edge(
+              edgeId1,
+              tagCache1.tag,
+              tagCache2.tag,
+              1,
+              '#ccc'
+          ));
+          this.graph_.addEdge(new Edge(
+              edgeId2,
+              tagCache2.tag,
+              tagCache1.tag,
+              1,
+              '#ccc'
+          ));
+        })
+      })
+    });
+  }
+}
+
+GraphBuilderRegistry.register('tags-graph-builder', TagsGraphBuilder);

--- a/src/graph-builders/tags.js
+++ b/src/graph-builders/tags.js
@@ -12,9 +12,9 @@
 
 
 import {GraphBuilder} from './i-graphbuilder';
-import {Node} from "../../sigma/src/classes/sigma.classes.node";
-import {Edge} from "../../sigma/src/classes/sigma.classes.edge";
-import {GraphBuilderRegistry} from "./graph-builders-registry";
+import {Node} from '../../sigma/src/classes/sigma.classes.node';
+import {Edge} from '../../sigma/src/classes/sigma.classes.edge';
+import {GraphBuilderRegistry} from './graph-builders-registry';
 
 
 const NOTES = 'notes';
@@ -45,8 +45,8 @@ export class TagsGraphBuilder extends GraphBuilder {
   };
 
   /**
-   * Generates a graph that shows the connections between tags. Tags are
-   * connected if they appear together.
+   * Generates a graph that shows the connections between tags. Two tags are
+   * connected if there are one or more notes containing both tags.
    * @param {!Map<string, *>} config The current configuration of the graph.
    * @param {!Vault} vault The vault to use to generate the graph.
    * @param {!MetadataCache} metadataCache The metadata cache used to generate
@@ -89,8 +89,8 @@ export class TagsGraphBuilder extends GraphBuilder {
   }
 
   /**
-   * Adds nodes representing tags to the graph, and connects them. If two tags
-   * can be found in the same note, they are connected.
+   * Adds nodes representing tags to the graph, and connects them. Two tags are
+   * connected if there are one or more notes containing both tags.
    * @param {!Array<!TFile>} files All of the files in the vault.
    * @param {!MetadataCache} metadataCache The metadata cache used to generate
    *     the graph.

--- a/src/views/better-graph.js
+++ b/src/views/better-graph.js
@@ -14,8 +14,6 @@
 // Obsidian imports
 import {ItemView, WorkspaceLeaf, Vault} from 'obsidian';
 import {VIEW_TYPE_BETTER_GRAPH, VIEW_TYPE_GRAPH_SETTINGS} from '../constants';
-import {SimpleGraphBuilder} from '../graph-builders/simple';
-import {GraphSettingsView} from './graph-settings';
 
 // Sigma imports
 import '../../sigma/src/sigma.core';


### PR DESCRIPTION
### Description

Firstly, fixes some issues with the simple graph builder that were causing rendering to break when loading the LYT vault (which I used for testing tags).

Then adds a a graph builder that is tags-centered. This means that every edge in the graph connects to at least one tag. Tag *a* connects to tag *b* if the two tags are ever found in the same note. And (if you have notes enabled) note *a* connects to tag *b* if *a* contains *b*. This means that only notes which contain tags are added to the graph (if notes are enabled at all).

### Testing

Manually tested that the graph was created correctly using the [LYT vault](https://publish.obsidian.md/lyt-kit/_START+HERE), which I downloaded.

Manually tested enabling and disabling notes on the tags graph.

It seems that there are some issues with the Simple graph builder that LYT has revealed, but I'll fix those in a follow-up.