### PR TITLE
Fixup notes graph builder

### DIFF
--- a/src/views/graph-settings.js
+++ b/src/views/graph-settings.js
@@ -21,7 +21,7 @@ import {
 import {VIEW_TYPE_BETTER_GRAPH, VIEW_TYPE_GRAPH_SETTINGS} from "../constants";
 import {GraphBuilderRegistry} from '../graph-builders/graph-builders-registry';
 import {GraphBuilder} from '../graph-builders/i-graphbuilder';
-import {SimpleGraphBuilder} from '../graph-builders/simple';
+import {NotesGraphBuilder} from '../graph-builders/notes';
 import {TagsGraphBuilder} from '../graph-builders/tags';
 
 


### PR DESCRIPTION
### Description

Renames the 'Simple' graph builder to 'Notes'. I think that this is a more descriptive name, that will work better with future graph builders I want to create. The name of the graph builder denotes the "main" type of node in the graph. These are the nodes that connect to eachother. Eg in the 'Notes' graph, notes connect to eachother, and in the 'Tags' graph, tags connect to eachother. Additional nodes connect to those "main" nodes.

Also fixes some bugs with the notes graph builder.
1) Tag and attachments edges were not doing proper duplicate checks.
2) Notes that used to be orphans were not getting added to the graph when other nodes (like tags) were getting added to the graph.

### Testing

Manually tested that turning off and on all of the options worked correctly and didn't throw errors. Tested with orphans enabled and orphans disabled.