### PR TITLE
Add PIXI

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,7 @@
     "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
     "rollup": "^2.32.1"
   },
-  "dependencies": {}
+  "dependencies": {
+    "pixi.js": "^5.3.3"
+  }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,6 +8,7 @@ body {
 }
 
 #graph-container {
+    overflow: hidden;
     width: 100%;
     height: 100%;
 }

--- a/src/views/better-graph.js
+++ b/src/views/better-graph.js
@@ -14,6 +14,7 @@
 // Obsidian imports
 import {ItemView, WorkspaceLeaf, Vault} from 'obsidian';
 import {VIEW_TYPE_BETTER_GRAPH, VIEW_TYPE_GRAPH_SETTINGS} from '../constants';
+import * as PIXI from 'pixi.js';
 
 // Sigma imports
 import '../../sigma/src/sigma.core';
@@ -106,6 +107,29 @@ export class BetterGraphView extends ItemView {
     if (this.settingsView_) {
       this.settingsView_.view.setGraphView(this);
     }
+
+    // For testing PIXI!
+    this.pixi_ = new PIXI.Application({
+      antialias: true,
+      transparent: true,
+    });
+    this.graphContainer_.appendChild(this.pixi_.view);
+    this.onResize();
+
+    let circle = new PIXI.Graphics();
+    circle.beginFill(0x66ccff);
+    circle.lineStyle(4, 0xffee00, 1);
+    circle.drawCircle(0, 0, 32);
+    circle.endFill();
+    circle.x = 100;
+    circle.y = 100;
+    this.pixi_.stage.addChild(circle);
+  }
+
+  onResize() {
+    const rect = this.graphContainer_.getBoundingClientRect();
+    const container = this.graphContainer_;
+    this.pixi_.renderer.resize(container.offsetWidth, container.offsetHeight);
   }
 
   /**

--- a/src/views/graph-settings.js
+++ b/src/views/graph-settings.js
@@ -143,6 +143,7 @@ export class GraphSettingsView extends ItemView {
    * @param {BetterGraphView} graphView The better graph view.
    */
   setGraphView(graphView) {
+    return;
     this.sigma_ = new sigma({
       renderer: {
         container: graphView.getGraphContainer(),


### PR DESCRIPTION
### Description

Adds PIXI as a dependency of this project and creates a "Hello World" program testing it.

The main reason I decided to go with PIXI is because it's what Obsidian uses for its built-in graph rendering. It seems to be fast, and pretty easy to work with.

### Testing

Tested that the "Hello World" program renders correctly, and that the canvas gets properly resized when the view size changes.