### PR TITLE
Add basics of new rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "rollup": "^2.32.1"
   },
   "dependencies": {
+    "d3-force": "^2.1.1",
     "pixi.js": "^5.3.3"
   }
 }

--- a/src/graph-builders/i-graphbuilder.js
+++ b/src/graph-builders/i-graphbuilder.js
@@ -12,7 +12,8 @@
 'use strict';
 
 
-import {Vault, MetadataCache} from 'obsidian';
+import {Vault, MetadataCache, Events, EventRef} from 'obsidian';
+import {Graph} from '../graph/graph';
 
 
 /**
@@ -20,38 +21,7 @@ import {Vault, MetadataCache} from 'obsidian';
  * graph.
  * @interface
  */
-export class GraphBuilder {
-
-  /**
-   * Sets the graph we will build.
-   * @param {Object} graph The graph we will build.
-   */
-  setGraph(graph) {
-    this.graph_ = graph;
-  }
-
-  /**
-   * Generates a graph for the given vault.
-   * @param {!Map<string, *>} config The current configuration of the graph
-   *     builder.
-   * @param {!Vault} vault The vault to used to generate the graph.
-   * @param {!MetadataCache} metadataCache The metadata cache used to generate
-   *     the graph.
-   */
-  generateGraph(config, vault, metadataCache) {}
-
-
-  /**
-   * Called when the configuration updates. Graph should be modified
-   * accordingly.
-   * @param {!Map<string, *>} oldConfig The old configuration.
-   * @param {!Map<string, *>} newConfig The new configuration.
-   * @param {!Vault} vault The vault to used to generate the graph.
-   * @param {!MetadataCache} metadataCache The metadata cache used to generate
-   *     the graph.
-   */
-  onConfigUpdate(oldConfig, newConfig, vault, metadataCache) {}
-
+export class GraphBuilder extends Events {
   /**
    * Returns the display name of this graph builder.
    * @return {string} The display name of this graph builder.
@@ -100,5 +70,59 @@ export class GraphBuilder {
    */
   getConfig() {
     return [];
+  }
+
+  /**
+   * Sets the graph we will build.
+   * @param {Graph} graph The graph we will build.
+   */
+  setGraph(graph) {
+    this.graph_ = graph;
+  }
+
+  /**
+   * Returns the graph of the graph builder.
+   * @return {Graph} The graph of the graph builder.
+   */
+  getGraph() {
+    return this.graph_;
+  }
+
+  /**
+   * Generates a graph for the given vault.
+   * @param {!Map<string, *>} config The current configuration of the graph
+   *     builder.
+   * @param {!Vault} vault The vault to used to generate the graph.
+   * @param {!MetadataCache} metadataCache The metadata cache used to generate
+   *     the graph.
+   */
+  generateGraph(config, vault, metadataCache) {}
+
+  /**
+   * Called when the configuration updates. Graph should be modified
+   * accordingly.
+   * @param {!Map<string, *>} oldConfig The old configuration.
+   * @param {!Map<string, *>} newConfig The new configuration.
+   * @param {!Vault} vault The vault to used to generate the graph.
+   * @param {!MetadataCache} metadataCache The metadata cache used to generate
+   *     the graph.
+   */
+  onConfigUpdate(oldConfig, newConfig, vault, metadataCache) {}
+
+  /**
+   * Adds a listener to events from this graph builder.
+   * @param {string} name The name of the event to listen to. Currently supports:
+   *   - 'structure-update'
+   * @param {function(*): *} callback The listener to call.
+   * @param {?Object} ctx The context to call the event in.
+   * @return {!EventRef} The reference to the subscribed event.
+   * @throws If the passed name is not a valid event name.
+   */
+  on(name, callback, ctx) {
+    if (name == 'structure-update') {
+      return super.on(name, callback, ctx);
+    } else {
+      throw 'Unknown graph builder event: "' + name + '".';
+    }
   }
 }

--- a/src/graph-builders/notes.js
+++ b/src/graph-builders/notes.js
@@ -261,9 +261,9 @@ export class NotesGraphBuilder extends GraphBuilder {
    * @private
    */
   removeNonExistingFiles_(files, metadataCache) {
-    for (const node of this.graph_.nodes()) {
+    for (const node of this.graph_.getNodes()) {
       if (node.isNonExisting) {
-        this.graph_.dropNode(node.id);
+        this.graph_.removeNode(node.id);
       }
     }
   }
@@ -322,9 +322,9 @@ export class NotesGraphBuilder extends GraphBuilder {
    * @private
    */
   removeTags_(files, metadataCache) {
-    for (const node of this.graph_.nodes()) {
+    for (const node of this.graph_.getNodes()) {
       if (node.isTag) {
-        this.graph_.dropNode(node.id);
+        this.graph_.removeNode(node.id);
       }
     }
   }
@@ -386,9 +386,9 @@ export class NotesGraphBuilder extends GraphBuilder {
    * @private
    */
   removeAttachments_(files, metadataCache) {
-    for (const node of this.graph_.nodes()) {
+    for (const node of this.graph_.getNodes()) {
       if (node.isAttachment) {
-        this.graph_.dropNode(node.id);
+        this.graph_.removeNode(node.id);
       }
     }
   }
@@ -402,7 +402,7 @@ export class NotesGraphBuilder extends GraphBuilder {
    */
   addOrphans_(files, metadataCache) {
     const existingNodeIds = new Set();
-    this.graph_.nodes().forEach((node) => {
+    this.graph_.getNodes().forEach((node) => {
       existingNodeIds.add(node.id);
     });
 
@@ -431,14 +431,14 @@ export class NotesGraphBuilder extends GraphBuilder {
   removeOrphans_(files, metadataCache) {
     const referencedNodeIds = new Set();
 
-    this.graph_.edges().forEach((edge) => {
+    this.graph_.getEdges().forEach((edge) => {
       referencedNodeIds.add(edge.source);
       referencedNodeIds.add(edge.target);
     });
 
-    this.graph_.nodes().forEach((node) => {
+    this.graph_.getNodes().forEach((node) => {
       if (!referencedNodeIds.has(node.id)) {
-        this.graph_.dropNode(node.id);
+        this.graph_.removeNode(node.id);
       }
     })
   }

--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -67,7 +67,7 @@ export class Graph {
   }
 
   /**
-   * Returns an array of all of the nodes in the graph.
+   * Returns a shallow copied array of all of the nodes in the graph.
    * @return {!Array<!Node>} All of the nodes in the graph.
    */
   getNodes() {
@@ -104,7 +104,7 @@ export class Graph {
   }
 
   /**
-   * Returns an array of all of the edges in the graph.
+   * Returns a shallow copied array of all of the edges in the graph.
    * @return {!Array<!Edge>} All of the edges in the graph.
    */
   getEdges() {

--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -67,6 +67,16 @@ export class Graph {
   }
 
   /**
+   * Returns the node with the specified id (if it exists).
+   * @param {string} nodeId The node id of the node we want to find.
+   * @return {?Node} The node with the specified id, or undefined if it does
+   *     not exist.
+   */
+  getNode(nodeId) {
+    return this.nodes_.find(node => node.id == nodeId);
+  }
+
+  /**
    * Returns a shallow copied array of all of the nodes in the graph.
    * @return {!Array<!Node>} All of the nodes in the graph.
    */
@@ -101,6 +111,16 @@ export class Graph {
    */
   hasEdge(edgeId) {
     return this.edges_.some(edge => edge.id == edgeId)
+  }
+
+  /**
+   * Returns the edge with the specified id (if it exists).
+   * @param {string} edgeId The edge id of the edge we want to find.
+   * @return {?Edge} The edge with the specified id, or undefined if it does
+   *     not exist.
+   */
+  getEdge(edgeId) {
+    return this.edges_.find(edge => edge.id == edgeId);
   }
 
   /**

--- a/src/layouts/force-directed-1.js
+++ b/src/layouts/force-directed-1.js
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2020 Obsidian Better Graph View
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Class for the first force-directed layout algorithm. Layout
+ *     algorithms define where the nodes are positioned in the. They do *not*
+ *     define which nodes are connected to other nodes (that is the job of a
+ *     graph builder).
+ * @author bekawestberg@gmail.com (Beka Westberg)
+ */
+'use strict';
+
+import {forceSimulation, forceCenter, forceCollide} from 'd3-force';
+import {Layout} from './i-layout';
+import {Graph} from '../graph/graph';
+
+export class ForceDirected1 extends Layout {
+  constructor() {
+    super();
+    /**
+     * The current graph being operated on by this layout.
+     * @type {Graph}
+     * @private
+     */
+    this.graph_ = null;
+
+    /**
+     * The force simulation associated with this layout.
+     * @type {!Object}
+     */
+    this.simulation_ = forceSimulation();
+
+    this.simulation_
+        .force('collide', forceCollide())
+        .force('center', forceCenter());
+
+    this.simulation_.on('tick', this.onSimulationUpdate.bind(this));
+  }
+
+  /**
+   * Called when the structure of the graph updates.
+   * @param {Graph} graph The graph that has been updated.
+   */
+  onGraphUpdate(graph) {
+    this.graph_ = graph;
+    this.simulation_
+        .nodes(graph.getNodes())
+        .restart();
+  }
+
+  /**
+   * Called when the simulation updates.
+   */
+  onSimulationUpdate() {
+    this.trigger('layout-update', this.graph_);
+  }
+}

--- a/src/layouts/force-directed.js
+++ b/src/layouts/force-directed.js
@@ -5,10 +5,7 @@
  */
 
 /**
- * @fileoverview Class for the first force-directed layout algorithm. Layout
- *     algorithms define where the nodes are positioned in the. They do *not*
- *     define which nodes are connected to other nodes (that is the job of a
- *     graph builder).
+ * @fileoverview Class for the first force-directed layout algorithm.
  * @author bekawestberg@gmail.com (Beka Westberg)
  */
 'use strict';
@@ -41,7 +38,8 @@ export class ForceDirectedLayout extends Layout {
   }
 
   /**
-   * Called when the structure of the graph updates.
+   * Called when the structure of the graph updates. Passes the new structure
+   * to the simulation.
    * @param {Graph} graph The graph that has been updated.
    */
   onGraphUpdate(graph) {
@@ -52,7 +50,7 @@ export class ForceDirectedLayout extends Layout {
   }
 
   /**
-   * Called when the simulation updates.
+   * Called when the simulation updates. Triggers the layout update event.
    */
   onSimulationUpdate() {
     this.trigger('layout-update', this.graph_);

--- a/src/layouts/force-directed.js
+++ b/src/layouts/force-directed.js
@@ -17,7 +17,7 @@ import {forceSimulation, forceCenter, forceCollide} from 'd3-force';
 import {Layout} from './i-layout';
 import {Graph} from '../graph/graph';
 
-export class ForceDirected1 extends Layout {
+export class ForceDirectedLayout extends Layout {
   constructor() {
     super();
     /**
@@ -34,8 +34,8 @@ export class ForceDirected1 extends Layout {
     this.simulation_ = forceSimulation();
 
     this.simulation_
-        .force('collide', forceCollide())
-        .force('center', forceCenter());
+        .force('collide', forceCollide(32))
+        .force('center', forceCenter(250, 450));
 
     this.simulation_.on('tick', this.onSimulationUpdate.bind(this));
   }

--- a/src/layouts/i-layout.js
+++ b/src/layouts/i-layout.js
@@ -6,8 +6,8 @@
 
 /**
  * @fileoverview Interface for a layout algorithm. Layout algorithms define
- *     where the nodes are positioned in the. They do *not* define which nodes
- *     are connected to other nodes (that is the job of a graph builder).
+ *     where the nodes are positioned. They do *not* define which nodes are
+ *     connected to other nodes (that is the job of a graph builder).
  * @author bekawestberg@gmail.com (Beka Westberg)
  */
 'use strict';

--- a/src/layouts/i-layout.js
+++ b/src/layouts/i-layout.js
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2020 Obsidian Better Graph View
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Interface for a layout algorithm. Layout algorithms define
+ *     where the nodes are positioned in the. They do *not* define which nodes
+ *     are connected to other nodes (that is the job of a graph builder).
+ * @author bekawestberg@gmail.com (Beka Westberg)
+ */
+'use strict';
+
+
+import {Events, EventRef} from 'obsidian';
+import {GraphBuilder} from '../graph-builders/i-graphbuilder';
+import {Graph} from '../graph/graph';
+
+
+/**
+ * @interface
+ */
+export class Layout extends Events {
+  /**
+   * Subscribes this layout to the given graph builder.
+   * @param {GraphBuilder} graphBuilder The graph builder to subscribe to.
+   */
+  setGraphBuilder(graphBuilder) {
+    graphBuilder.on('structure-update', this.onGraphUpdate, this);
+    this.onGraphUpdate(graphBuilder.getGraph());
+  }
+
+  /**
+   * Called when the structure of the graph changes.
+   * @param {Graph} graph The graph that has just been updated.
+   */
+  onGraphUpdate(graph) {}
+
+  /**
+   * Adds a listener to events from this layout.
+   * @param {string} name The name of the event to listen to. Currently supports:
+   *   - 'layout-update'
+   * @param {function(*): *} callback The listener to call.
+   * @param {?Object} ctx The context to call the event in.
+   * @return {!EventRef} The reference to the subscribed event.
+   * @throws If the passed name is not a valid event name.
+   */
+  on(name, callback, ctx) {
+    if (name == 'layout-update') {
+      return super.on(name, callback, ctx);
+    } else {
+      throw 'Unknown layout event: "' + name + '".';
+    }
+  }
+}

--- a/src/renderers/i-renderer.js
+++ b/src/renderers/i-renderer.js
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2020 Obsidian Better Graph View
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Interface for a graph renderer. Renderers draw a graph which
+ *     has been built and laid out to a PIXI stage.
+ * @author bekawestberg@gmail.com (Beka Westberg)
+ */
+'use strict';
+
+
+import * as PIXI from 'pixi.js';
+import {Layout} from '../layouts/i-layout';
+import {Graph} from '../graph/graph';
+
+
+export class Renderer {
+  /**
+   * Constructs a renderer instance given the PIXI Application instance.
+   * @param {!PIXI.Application} pixiApp The pixi application this renderer
+   *     will render to.
+   */
+  constructor(pixiApp) {
+    this.pixi_ = pixiApp;
+  }
+
+  /**
+   * Subscribes this renderer to the given graph layout.
+   * @param {Layout} layout
+   */
+  setLayout(layout) {
+    layout.on('layout-update', this.onLayoutUpdate, this);
+  }
+
+  /**
+   * Called when the layout of the graph changes.
+   * @param {Graph} graph The graph that has just been updated.
+   */
+  onLayoutUpdate(graph) {}
+}

--- a/src/renderers/simple.js
+++ b/src/renderers/simple.js
@@ -127,7 +127,7 @@ export class Simple extends Renderer {
   /**
    * Adds any edges in the edge list that are not currently rendered, and
    * updates all of the rendered edges to match the data in the graph model.
-   * @param {!Array<!Edge>} edges All of the edges in the graph.
+   * @param {!Array<!Edge>} edges The current edges in teh graph.
    * @param {!Graph} graph The current graph.
    * @private
    */

--- a/src/renderers/simple.js
+++ b/src/renderers/simple.js
@@ -13,38 +13,162 @@
 
 
 import {Renderer} from './i-renderer';
+import {Graph} from '../graph/graph';
 import * as PIXI from 'pixi.js';
 
 
 export class Simple extends Renderer {
+  /**
+   * Constructs the simple renderer.
+   * @param {!PIXI.Application} pixiApp The pixi application this renderer
+   *     will render to.
+   */
   constructor(pixiApp) {
     super(pixiApp);
 
     /**
-     * Map of node ids to particle containers (which render the nodes).
-     * @type {Map<string, PIXI.Container>}
+     * Map of node ids to containers (which render the nodes).
+     * @type {!Map<string, PIXI.Container>}
      * @private
      */
     this.nodesMap_ = new Map();
+
+    /**
+     * Map of edge ids to containers (which render the edge).
+     * @type {!Map<string, PIXI.Container>}
+     * @private
+     */
+    this.edgesMap_ = new Map();
   }
 
+  /**
+   * Called when the layout of the graph changes. Redraws all of the positions
+   * of the nodes and edges.
+   * @param {!Graph} graph The graph to render.
+   */
   onLayoutUpdate(graph) {
-    graph.getNodes().forEach((node) => {
-      let container;
-      if (this.nodesMap_.has(node.id)) {
-        container = this.nodesMap_.get(node.id);
-      } else {
-        container = new PIXI.Container();
-        let circle = new PIXI.Graphics();
-        circle.beginFill(0x666666);
-        circle.drawCircle(0, 0, 32);
-        circle.endFill();
+    const nodes = graph.getNodes();
+    this.clearOldNodes_(nodes);
+    this.addNodes_(nodes);
+    this.layoutNodes_(nodes);
 
-        this.pixi_.stage.addChild(container);
-        container.addChild(circle);
-        this.nodesMap_.set(node.id, container);
+    const edges = graph.getEdges();
+    this.clearOldEdges_(edges);
+    this.updateEdges_(edges, graph);
+  }
+
+  /**
+   * Removes any rendered nodes that are not in the nodes list.
+   * @param {!Array<!Node>} nodes The current nodes in the graph.
+   * @private
+   */
+  clearOldNodes_(nodes) {
+    const nodesInGraph = new Set();
+    nodes.forEach(node => nodesInGraph.add(node.id));
+    for (const [id, container] of this.nodesMap_) {
+      if (!nodesInGraph.has(id)) {
+        this.pixi_.stage.removeChild(container);
+        container.destroy({children: true});
       }
-      container.setTransform(node.x, node.y);
+    }
+  }
+
+  /**
+   * Adds any nodes in the nodes list that are not currently rendered.
+   * @param {!Array<!Node>} nodes The current nodes in the graph.
+   * @private
+   */
+  addNodes_(nodes) {
+    nodes.forEach((node) => {
+      if (this.nodesMap_.has(node.id)) {
+        return;
+      }
+      const container = new PIXI.Container();
+      container.zIndex = 1;
+      const circle = new PIXI.Graphics();
+      circle.beginFill(0x666666);
+      circle.drawCircle(0, 0, 32);
+      circle.endFill();
+
+      this.pixi_.stage.addChild(container);
+      container.addChild(circle);
+      this.nodesMap_.set(node.id, container);
     })
+  }
+
+  /**
+   * Updates the positions of all of the rendered nodes to match the postions
+   * in the graph model.
+   * @param {!Array<!Node>} nodes The current nodes in the graph.
+   * @private
+   */
+  layoutNodes_(nodes) {
+    nodes.forEach((node) => {
+      this.nodesMap_.get(node.id).setTransform(node.x, node.y);
+    })
+  }
+
+  /**
+   * Removes any rendered edges that are not in the edges list.
+   * @param {!Array<!Edge>} edges The current edges in the graph.
+   * @private
+   */
+  clearOldEdges_(edges) {
+    const edgesInGraph = new Set();
+    edges.forEach(edge => edgesInGraph.add(edge.id));
+    for (const [id, container] of this.edgesMap_) {
+      if (!edgesInGraph.has(id)) {
+        this.pixi_.stage.removeChild(container);
+        container.destroy({children: true});
+      }
+    }
+  }
+
+  /**
+   * Adds any edges in the edge list that are not currently rendered, and
+   * updates all of the rendered edges to match the data in the graph model.
+   * @param {!Array<!Edge>} edges All of the edges in the graph.
+   * @param {!Graph} graph The current graph.
+   * @private
+   */
+  updateEdges_(edges, graph) {
+    edges.forEach((edge) => {
+      if (!this.edgesMap_.has(edge.id)) {
+        this.addEdge_(edge);
+      }
+      this.layoutEdge_(edge, this.edgesMap_.get(edge.id), graph);
+    })
+  }
+
+  /**
+   * Creates a container and graphics element for the given edge.
+   * @param {!Edge} edge The edge to create a PIXI element for.
+   * @private
+   */
+  addEdge_(edge) {
+    const container = new PIXI.Container();
+    const line = new PIXI.Graphics();
+    this.pixi_.stage.addChild(container);
+    container.addChild(line);
+    this.edgesMap_.set(edge.id, container);
+  }
+
+  /**
+   * Updates the given container to draw a line between the two nodes identified
+   * by the given edge.
+   * @param {!Edge} edge The model of the edge to layout.
+   * @param {!PIXI.Container} container The container to layout.
+   * @param {!Graph} graph The current graph.
+   * @private
+   */
+  layoutEdge_(edge, container, graph) {
+    const sourceNode = graph.getNode(edge.source);
+    const targetNode = graph.getNode(edge.target);
+
+    const line = container.getChildAt(0);
+    line.clear();
+    line.lineStyle(2, 0xcccccc, 1);
+    line.moveTo(sourceNode.x, sourceNode.y);
+    line.lineTo(targetNode.x, targetNode.y);
   }
 }

--- a/src/renderers/simple.js
+++ b/src/renderers/simple.js
@@ -10,3 +10,41 @@
  * @author bekawestberg@gmail.com (Beka Westberg)
  */
 'use strict';
+
+
+import {Renderer} from './i-renderer';
+import * as PIXI from 'pixi.js';
+
+
+export class Simple extends Renderer {
+  constructor(pixiApp) {
+    super(pixiApp);
+
+    /**
+     * Map of node ids to particle containers (which render the nodes).
+     * @type {Map<string, PIXI.Container>}
+     * @private
+     */
+    this.nodesMap_ = new Map();
+  }
+
+  onLayoutUpdate(graph) {
+    graph.getNodes().forEach((node) => {
+      let container;
+      if (this.nodesMap_.has(node.id)) {
+        container = this.nodesMap_.get(node.id);
+      } else {
+        container = new PIXI.Container();
+        let circle = new PIXI.Graphics();
+        circle.beginFill(0x666666);
+        circle.drawCircle(0, 0, 32);
+        circle.endFill();
+
+        this.pixi_.stage.addChild(container);
+        container.addChild(circle);
+        this.nodesMap_.set(node.id, container);
+      }
+      container.setTransform(node.x, node.y);
+    })
+  }
+}

--- a/src/renderers/simple.js
+++ b/src/renderers/simple.js
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright 2020 Obsidian Better Graph View
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Class for the default graph renderer. Uses simple circles and
+ *     lines to draw the graph.
+ * @author bekawestberg@gmail.com (Beka Westberg)
+ */
+'use strict';

--- a/src/views/better-graph.js
+++ b/src/views/better-graph.js
@@ -122,6 +122,7 @@ export class BetterGraphView extends ItemView {
     });
     this.graphContainer_.appendChild(this.pixi_.view);
     this.onResize();
+    this.pixi_.stage.sortableChildren = true;
 
     // let circle = new PIXI.Graphics();
     // circle.beginFill(0x66ccff);

--- a/src/views/better-graph.js
+++ b/src/views/better-graph.js
@@ -58,8 +58,11 @@ import '../../sigma/plugins/sigma.layout.forceAtlas2/supervisor';
 import '../../sigma/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes';
 
 import {NotesGraphBuilder} from '../graph-builders/notes';
-import {ForceDirected1} from '../layouts/force-directed-1';
+import {ForceDirectedLayout} from '../layouts/force-directed';
 import {Graph} from '../graph/graph';
+import {Simple} from '../renderers/simple';
+import {Node} from '../graph/node';
+import {Edge} from '../graph/edge';
 
 
 export class BetterGraphView extends ItemView {
@@ -120,20 +123,25 @@ export class BetterGraphView extends ItemView {
     this.graphContainer_.appendChild(this.pixi_.view);
     this.onResize();
 
-    let circle = new PIXI.Graphics();
-    circle.beginFill(0x66ccff);
-    circle.lineStyle(4, 0xffee00, 1);
-    circle.drawCircle(0, 0, 32);
-    circle.endFill();
-    circle.x = 100;
-    circle.y = 100;
-    this.pixi_.stage.addChild(circle);
+    // let circle = new PIXI.Graphics();
+    // circle.beginFill(0x66ccff);
+    // circle.lineStyle(4, 0xffee00, 1);
+    // circle.drawCircle(0, 0, 32);
+    // circle.endFill();
+    // circle.x = 100;
+    // circle.y = 100;
+    // this.pixi_.stage.addChild(circle);
 
     // For testing d3!
     const graph = new Graph();
+    graph.addNode(new Node('test'));
+    graph.addNode(new Node('test2'));
+    graph.addEdge(new Edge('test to test2', 'test', 'test2'));
     const builder = new NotesGraphBuilder();
+    const renderer = new Simple(this.pixi_);
+    const layout = new ForceDirectedLayout();
+    renderer.setLayout(layout);
     builder.setGraph(graph);
-    const layout = new ForceDirected1();
     layout.setGraphBuilder(builder);
   }
 

--- a/src/views/better-graph.js
+++ b/src/views/better-graph.js
@@ -57,6 +57,10 @@ import '../../sigma/plugins/sigma.layout.forceAtlas2/supervisor';
 // Sigma drag imports.
 import '../../sigma/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes';
 
+import {NotesGraphBuilder} from '../graph-builders/notes';
+import {ForceDirected1} from '../layouts/force-directed-1';
+import {Graph} from '../graph/graph';
+
 
 export class BetterGraphView extends ItemView {
 
@@ -124,6 +128,13 @@ export class BetterGraphView extends ItemView {
     circle.x = 100;
     circle.y = 100;
     this.pixi_.stage.addChild(circle);
+
+    // For testing d3!
+    const graph = new Graph();
+    const builder = new NotesGraphBuilder();
+    builder.setGraph(graph);
+    const layout = new ForceDirected1();
+    layout.setGraphBuilder(builder);
   }
 
   onResize() {


### PR DESCRIPTION
### Description

Adds the bones for the new PIXI-based rendering.

Includes a new layout class, which controls the positions of the nodes in the graph. Implemented a simple d3-force based layouter.

And includes a new renderer class, which handles rendering the nodes (which have been positioned by the layouter) and the edges between them.

I also moved everything over to an observer pattern (publisher/subscriber patter) using the built-in Events class from obsidian. So the Renderer watches the Layout which watches the GraphBuilder which will eventually watch for file edits and things.

The next step will be connecting this up to the settings view, so that we can actually render a vault, and getting rid of the sigma junk. I'm going to fix up the force-directed layout then as well. Then I'm going to work on better navigation, different types of nodes, etc.

### Testing

You can see in the code that I currently have test code inside the better graph view. It is working correctly. I really wish I had some unit tests though lol.