### PR TITLE
Add more rendering features to the simple renderer

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -14,7 +14,7 @@
 import {Plugin} from 'obsidian';
 import {BetterGraphView} from './views/better-graph';
 import {GraphSettingsView} from './views/graph-settings';
-import {VIEW_TYPE_BETTER_GRAPH, VIEW_TYPE_GRAPH_SETTINGS} from './constants';
+import {VIEW_TYPE_BETTER_GRAPH, VIEW_TYPE_GRAPH_SETTINGS} from './utils/constants';
 
 
 export default class BetterGraphPlugin extends Plugin {

--- a/src/graph-builders/notes.js
+++ b/src/graph-builders/notes.js
@@ -27,7 +27,7 @@ import {
   tagToId,
   attachmentToId
 } from '../utils/ids';
-import {AttachmentNode} from "../graph/attachment-node";
+import {AttachmentNode} from '../graph/attachment-node';
 
 
 const TAGS = 'tags';

--- a/src/graph-builders/notes.js
+++ b/src/graph-builders/notes.js
@@ -237,11 +237,11 @@ export class NotesGraphBuilder extends GraphBuilder {
    * @private
    */
   removeNonExistingFiles_(files, metadataCache) {
-    for (const node of this.graph_.getNodes()) {
+    this.graph_.forEachNode((node) => {
       if (node.isNonExisting) {
         this.graph_.removeNode(node.id);
       }
-    }
+    });
   }
 
   /**
@@ -285,11 +285,11 @@ export class NotesGraphBuilder extends GraphBuilder {
    * @private
    */
   removeTags_(files, metadataCache) {
-    for (const node of this.graph_.getNodes()) {
+    this.graph_.forEachNode((node) => {
       if (node.isTag) {
         this.graph_.removeNode(node.id);
       }
-    }
+    });
   }
 
   /**
@@ -336,11 +336,11 @@ export class NotesGraphBuilder extends GraphBuilder {
    * @private
    */
   removeAttachments_(files, metadataCache) {
-    for (const node of this.graph_.getNodes()) {
+    this.graph_.forEachNode((node) => {
       if (node.isAttachment) {
         this.graph_.removeNode(node.id);
       }
-    }
+    });
   }
 
   /**
@@ -352,7 +352,7 @@ export class NotesGraphBuilder extends GraphBuilder {
    */
   addOrphans_(files, metadataCache) {
     const existingNodeIds = new Set();
-    this.graph_.getNodes().forEach((node) => {
+    this.graph_.forEachNode((node) => {
       existingNodeIds.add(node.id);
     });
 
@@ -374,7 +374,7 @@ export class NotesGraphBuilder extends GraphBuilder {
   removeOrphans_(files, metadataCache) {
     const referencedNodeIds = new Set();
 
-    this.graph_.getEdges().forEach((edge) => {
+    this.graph_.forEachEdge((edge) => {
       referencedNodeIds.add(
           typeof edge.source == 'object' ? edge.source.id : edge.source);
       referencedNodeIds.add(
@@ -382,7 +382,7 @@ export class NotesGraphBuilder extends GraphBuilder {
 
     });
 
-    this.graph_.getNodes().forEach((node) => {
+    this.graph_.forEachNode((node) => {
       if (!referencedNodeIds.has(node.id)) {
         this.graph_.removeNode(node.id);
       }

--- a/src/graph-builders/notes.js
+++ b/src/graph-builders/notes.js
@@ -17,6 +17,7 @@ import {GraphBuilder} from './i-graphbuilder';
 import {Node} from '../graph/node';
 import {Edge} from '../graph/edge';
 import {GraphBuilderRegistry} from './graph-builders-registry';
+import {NoteNode} from "../graph/note-node";
 
 
 const TAGS = 'tags';
@@ -160,9 +161,12 @@ export class NotesGraphBuilder extends GraphBuilder {
 
     // Create nodes.
     files.forEach((file) => {
-      const id = metadataCache.fileToLinktext(file, file.path);
-      createdFileIds.add(id);
-      this.graph_.addNode(new Node(id, file.basename));
+      // const id = metadataCache.fileToLinktext(file, file.path);
+      // createdFileIds.add(id);
+      // this.graph_.addNode(new Node(id, file.basename));
+      const node = new NoteNode(file, metadataCache);
+      createdFileIds.add(node.id);
+      this.graph_.addNode(node);
     });
 
     // Create edges.

--- a/src/graph-builders/tags.js
+++ b/src/graph-builders/tags.js
@@ -114,7 +114,6 @@ export class TagsGraphBuilder extends GraphBuilder {
       tags.forEach((tag) => {
         const tagId = tagToId(tag);
         if (!createdTagIds.has(tagId)) {
-          console.log('adding tag', tag);
           createdTagIds.add(tagId);
           this.graph_.addNode(new TagNode(tag));
         }

--- a/src/graph-builders/tags.js
+++ b/src/graph-builders/tags.js
@@ -11,10 +11,13 @@
 'use strict';
 
 
+import {getAllTags} from 'obsidian';
 import {GraphBuilder} from './i-graphbuilder';
-import {Node} from '../graph/node';
 import {Edge} from '../graph/edge';
 import {GraphBuilderRegistry} from './graph-builders-registry';
+import {fileToId, getEdgeId, tagToId} from '../utils/ids';
+import {TagNode} from '../graph/tag-node';
+import {NoteNode} from '../graph/note-node';
 
 
 const NOTES = 'notes';
@@ -105,33 +108,35 @@ export class TagsGraphBuilder extends GraphBuilder {
 
     files.forEach((file) => {
       const cache = metadataCache.getFileCache(file);
-      if (!cache.tags) {
-        return;
-      }
+      const tags = getAllTags(cache);
 
       // Create nodes.
-      cache.tags.forEach((tagCache) => {
-        if (!createdTagIds.has(tagCache.tag)) {
-          createdTagIds.add(tagCache.tag);
-          this.graph_.addNode(new Node(tagCache.tag, tagCache.tag));
+      tags.forEach((tag) => {
+        const tagId = tagToId(tag);
+        if (!createdTagIds.has(tagId)) {
+          console.log('adding tag', tag);
+          createdTagIds.add(tagId);
+          this.graph_.addNode(new TagNode(tag));
         }
       });
 
       // Create edges.
-      cache.tags.forEach((tagCache1) => {
-        cache.tags.forEach((tagCache2) => {
-          if (tagCache1.tag == tagCache2.tag) {
+      tags.forEach((tag1) => {
+        tags.forEach((tag2) => {
+          if (tag1 == tag2) {
             return;
           }
-          const edgeId1 = tagCache1.tag + ' to ' + tagCache2.tag;
-          const edgeId2 = tagCache2.tag + ' to ' + tagCache1.tag;
-          if (createdEdgeIds.has(edgeId1) || createdEdgeIds.has(edgeId2)) {
+          const tag1Id = tagToId(tag1);
+          const tag2Id = tagToId(tag2);
+          const edge1Id = getEdgeId(tag1Id, tag2Id);
+          const edge2Id = getEdgeId(tag2Id, tag1Id);
+          if (createdEdgeIds.has(edge1Id) || createdEdgeIds.has(edge2Id)) {
             return;
           }
-          createdEdgeIds.add(edgeId1);
-          createdEdgeIds.add(edgeId2);
-          this.graph_.addEdge(new Edge(edgeId1, tagCache1.tag, tagCache2.tag));
-          this.graph_.addEdge(new Edge(edgeId2, tagCache2.tag, tagCache1.tag));
+          createdEdgeIds.add(edge1Id);
+          createdEdgeIds.add(edge2Id);
+          this.graph_.addEdge(new Edge(edge1Id, tag1Id, tag2Id));
+          this.graph_.addEdge(new Edge(edge2Id, tag2Id, tag1Id));
         })
       })
     });
@@ -154,18 +159,17 @@ export class TagsGraphBuilder extends GraphBuilder {
         return;
       }
 
-      const fileId = metadataCache.fileToLinktext(file, file.path);
-      const node = new Node(fileId, file.basename);
-      node.isNote = true;
-      this.graph_.addNode(node);
+      this.graph_.addNode(new NoteNode(file, metadataCache));
 
-      cache.tags.forEach((tagCache) => {
-        const edgeId = fileId + ' to ' + tagCache.tag;
+      getAllTags(cache).forEach((tag) => {
+        const fileId = fileToId(file, metadataCache);
+        const tagId = tagToId(tag);
+        const edgeId = getEdgeId(fileId, tagId);
         if (createdEdgeIds.has(edgeId)) {
           return;
         }
         createdEdgeIds.add(edgeId);
-        this.graph_.addEdge(new Edge(edgeId, fileId, tagCache.tag));
+        this.graph_.addEdge(new Edge(edgeId, fileId, tagId));
       })
     })
   }
@@ -179,7 +183,7 @@ export class TagsGraphBuilder extends GraphBuilder {
    */
   removeNotes_(files, metadataCache) {
     this.graph_.forEachNode((node) => {
-      if (node.isNote) {
+      if (node instanceof NoteNode) {
         this.graph_.removeNode(node.id);
       }
     })

--- a/src/graph-builders/tags.js
+++ b/src/graph-builders/tags.js
@@ -160,8 +160,8 @@ export class TagsGraphBuilder extends GraphBuilder {
 
       this.graph_.addNode(new NoteNode(file, metadataCache));
 
+      const fileId = fileToId(file, metadataCache);
       getAllTags(cache).forEach((tag) => {
-        const fileId = fileToId(file, metadataCache);
         const tagId = tagToId(tag);
         const edgeId = getEdgeId(fileId, tagId);
         if (createdEdgeIds.has(edgeId)) {

--- a/src/graph-builders/tags.js
+++ b/src/graph-builders/tags.js
@@ -178,7 +178,7 @@ export class TagsGraphBuilder extends GraphBuilder {
    * @private
    */
   removeNotes_(files, metadataCache) {
-    this.graph_.getNodes().forEach((node) => {
+    this.graph_.forEachNode((node) => {
       if (node.isNote) {
         this.graph_.removeNode(node.id);
       }

--- a/src/graph/attachment-node.js
+++ b/src/graph/attachment-node.js
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2020 Obsidian Better Graph View
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Class for a model of a note node in a graph.
+ * @author bekawestberg@gmail.com (Beka Westberg)
+ */
+'use strict';
+
+
+import {Node} from './node';
+import {EmbedCache} from 'obsidian';
+import {attachmentToId} from '../utils/ids';
+import {ATTACHMENTS_PREFIX} from '../utils/constants';
+
+export class AttachmentNode extends Node {
+  /**
+   * Constructs a node representing an attachment.
+   * @param {!EmbedCache} attachment The attachment.
+   */
+  constructor(attachment) {
+    super(attachmentToId(attachment), attachment.link);
+
+    this.classes_.push('attachment');
+
+    const types = attachment.link.split('.');
+    for (let i = 1; i < types.length; i++) {
+      this.classes_.push(ATTACHMENTS_PREFIX + types[i]);
+    }
+  }
+}

--- a/src/graph/attachment-node.js
+++ b/src/graph/attachment-node.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * @fileoverview Class for a model of a note node in a graph.
+ * @fileoverview Class for a model of a attachment node in a graph.
  * @author bekawestberg@gmail.com (Beka Westberg)
  */
 'use strict';

--- a/src/graph/edge.js
+++ b/src/graph/edge.js
@@ -42,6 +42,8 @@ export class Edge {
 
     /**
      * The pixi container holding all of the edge's rendered elements.
+     * The edge must own the container to allow for the builder and layout to
+     * bind mouse events to it.
      * @type {PIXI.Container}
      * @private
      */
@@ -58,6 +60,7 @@ export class Edge {
 
   /**
    * Returns the id of the source node for this edge.
+   * @return {string} The id of the source node.
    */
   getSourceId() {
     return typeof this.source == 'string' ? this.source : this.source.id;
@@ -65,6 +68,7 @@ export class Edge {
 
   /**
    * Returns the id of the target node for this edge.
+   * @return {string} The id of the target node.
    */
   getTargetId() {
     return typeof this.target == 'string' ? this.target : this.target.id;
@@ -72,13 +76,15 @@ export class Edge {
 
   /**
    * Returns the container which holds all of this edge's rendered elements.
+   * @return {!PIXI.Container} The id container holding this edge's rendered
+   *     elements
    */
   getContainer() {
     return this.container_;
   }
 
   /**
-   * Returns the css class names associated with this node.
+   * Returns the css class names associated with this edge.
    * @return {!Array<string>} The css class names associated with this edge.
    */
   getClasses() {

--- a/src/graph/edge.js
+++ b/src/graph/edge.js
@@ -11,6 +11,9 @@
 'use strict';
 
 
+import * as PIXI from 'pixi.js';
+
+
 export class Edge {
   /**
    * Constructs an edge with the given id, source id, and target id.
@@ -36,6 +39,13 @@ export class Edge {
      * @type {string|Node}
      */
     this.target = targetId;
+
+    /**
+     * The pixi container holding all of the edge's rendered elements.
+     * @type {PIXI.Container}
+     * @private
+     */
+    this.container_ = new PIXI.Container();
   }
 
   /**
@@ -53,6 +63,13 @@ export class Edge {
   }
 
   /**
+   * Returns the container which holds all of this edge's rendered elements.
+   */
+  getContainer() {
+    return this.container_;
+  }
+
+  /**
    * Returns true if this edge is connected to the given node id.
    * @param {string} nodeId The node id to check if this edge is connected to.
    */
@@ -60,4 +77,11 @@ export class Edge {
     return this.getSourceId() == nodeId || this.getTargetId() == nodeId;
   }
 
+  /**
+   * Disposes of this edge.
+   */
+  destroy() {
+    this.container_.parent && this.container_.parent.removeChild(this.container_);
+    this.container_.destroy({children: true});
+  }
 }

--- a/src/graph/edge.js
+++ b/src/graph/edge.js
@@ -46,6 +46,14 @@ export class Edge {
      * @private
      */
     this.container_ = new PIXI.Container();
+    this.container_.sortableChildren = true;
+
+    /**
+     * Css classes associated with this edge.
+     * @type {!Array<string>}
+     * @protected
+     */
+    this.classes_ = ['edge'];
   }
 
   /**
@@ -67,6 +75,14 @@ export class Edge {
    */
   getContainer() {
     return this.container_;
+  }
+
+  /**
+   * Returns the css class names associated with this node.
+   * @return {!Array<string>} The css class names associated with this edge.
+   */
+  getClasses() {
+    return this.classes_;
   }
 
   /**

--- a/src/graph/edge.js
+++ b/src/graph/edge.js
@@ -37,4 +37,27 @@ export class Edge {
      */
     this.target = targetId;
   }
+
+  /**
+   * Returns the id of the source node for this edge.
+   */
+  getSourceId() {
+    return typeof this.source == 'string' ? this.source : this.source.id;
+  }
+
+  /**
+   * Returns the id of the target node for this edge.
+   */
+  getTargetId() {
+    return typeof this.target == 'string' ? this.target : this.target.id;
+  }
+
+  /**
+   * Returns true if this edge is connected to the given node id.
+   * @param {string} nodeId The node id to check if this edge is connected to.
+   */
+  isConnectedToNode(nodeId) {
+    return this.getSourceId() == nodeId || this.getTargetId() == nodeId;
+  }
+
 }

--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -86,6 +86,18 @@ export class Graph {
   }
 
   /**
+   * Executes the provided function for each node in the graph. Loops backwards
+   * so that it is safe to remove nodes while iterating.
+   * @param {function(!Node)} callback The function to execute on each node.
+   * @param {?Object} thisArg the value to use as `this` when executing callback.
+   */
+  forEachNode(callback, thisArg) {
+    for (let i = this.nodes_.length - 1, node; (node = this.nodes_[i]); i--) {
+      callback.call(thisArg, node);
+    }
+  }
+
+  /**
    * Adds the given edge to the graph.
    * @param {!Edge} edge The edge to add to the graph.
    */
@@ -134,10 +146,28 @@ export class Graph {
   }
 
   /**
+   * Executes the provided function for each edge in the graph. Loops backwards
+   * so that it is safe to remove edges while iterating.
+   * @param {function(!Edge)} callback The function to execute on each edge.
+   * @param {?Object} thisArg the value to use as `this` when executing callback.
+   */
+  forEachEdge(callback, thisArg) {
+    for (let i = this.edges_.length - 1, edge; (edge = this.edges_[i]); i--) {
+      callback.call(thisArg, edge);
+    }
+  }
+
+  /**
    * Clears all of the nodes and edges from the graph.
    */
   clear() {
+    this.forEachNode((node) => {
+      node.destroy();
+    });
     this.nodes_.length = 0;
+    this.forEachEdge((edge) => {
+      edge.destroy();
+    });
     this.edges_.length = 0;
   }
 

--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -148,8 +148,18 @@ export class Graph {
    */
   getConnectedEdges(nodeId) {
     return this.edges_.filter((edge) => {
-      return edge.source.id == nodeId || edge.source == nodeId ||
-          edge.target.id == nodeId || edge.target == nodeId;
+      return edge.isConnectedToNode(nodeId);
     }).map(e => e.id);
+  }
+
+  /**
+   * Returns the number of edges that are connected to the node with the given
+   * node id.
+   * @param {string} nodeId The id of the node to find the degree of.
+   * @returns {number} The degree of the node with the given node id.
+   */
+  degree(nodeId) {
+    return this.edges_.reduce(
+        (acc, edge) => edge.isConnectedToNode(nodeId) ? ++acc : acc, 0);
   }
 }

--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -47,12 +47,13 @@ export class Graph {
   }
 
   /**
-   * Removes the node with the given node id from the graph. Also removes all
-   * connected edges.
+   * Removes the node with the given node id from the graph and destorys it.
+   * Also removes all connected edges.
    * @param {string} nodeId The id of the node to remove from the graph.
    */
   removeNode(nodeId) {
     this.getConnectedEdges(nodeId).forEach(edgeId => this.removeEdge(edgeId));
+    this.getNode(nodeId).destroy();
     this.nodes_.splice(this.nodes_.findIndex(n => n.id == nodeId), 1);
   }
 
@@ -96,10 +97,11 @@ export class Graph {
   }
 
   /**
-   * Removes the edge with the given edge id from the graph.
+   * Removes the edge with the given edge id from the graph and destroys it.
    * @param {string} edgeId The id of the edge to remove from the graph.
    */
   removeEdge(edgeId) {
+    this.getEdge(edgeId).destroy();
     this.edges_.splice(this.edges_.findIndex(e => e.id == edgeId), 1);
   }
 

--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -78,11 +78,11 @@ export class Graph {
   }
 
   /**
-   * Returns a shallow copied array of all of the nodes in the graph.
+   * Returns an array of all of the nodes in the graph.
    * @return {!Array<!Node>} All of the nodes in the graph.
    */
   getNodes() {
-    return [...this.nodes_];
+    return this.nodes_;
   }
 
   /**
@@ -126,11 +126,11 @@ export class Graph {
   }
 
   /**
-   * Returns a shallow copied array of all of the edges in the graph.
+   * Returns an array of all of the edges in the graph.
    * @return {!Array<!Edge>} All of the edges in the graph.
    */
   getEdges() {
-    return [...this.edges_];
+    return this.edges_;
   }
 
   /**

--- a/src/graph/node.js
+++ b/src/graph/node.js
@@ -75,6 +75,7 @@ export class Node {
      */
     this.container_ = new PIXI.Container();
     this.container_.zIndex = 1;
+    this.container_.sortableChildren = true;
 
     /**
      * A data object that can be used to store extra data about a node.
@@ -83,7 +84,7 @@ export class Node {
     this.data = new Map();
 
     /**
-     * Css classes associated with this note node.
+     * Css classes associated with this node.
      * @type {!Array<string>}
      * @protected
      */

--- a/src/graph/node.js
+++ b/src/graph/node.js
@@ -70,7 +70,7 @@ export class Node {
 
     /**
      * The pixi container holding all of the node's rendered elements.
-     * @type {PIXI.Container}
+     * @type {!PIXI.Container}
      * @private
      */
     this.container_ = new PIXI.Container();
@@ -86,9 +86,18 @@ export class Node {
 
   /**
    * Returns the container which holds all of this node's rendered elements.
+   * @return {!PIXI.Container}
    */
   getContainer() {
     return this.container_;
+  }
+
+  /**
+   * Returns the css class names associated with this node.
+   * @return {!Array<string>} The css class names associated with this node.
+   */
+  getClasses() {
+    return ['node'];
   }
 
   /**

--- a/src/graph/node.js
+++ b/src/graph/node.js
@@ -17,13 +17,20 @@ export class Node {
   /**
    * Constructs a node with the given id.
    * @param {string} id The id of the node. Must be unique within graph.
+   * @param {string} displayText The display text associated with this node.
    */
-  constructor(id) {
+  constructor(id, displayText) {
     /**
      * The id of the node.
      * @type {string}
      */
     this.id = id;
+
+    /**
+     * The display text of the node.
+     * @types {string}
+     */
+    this.displayText = displayText;
 
     /**
      * The x position of the node.

--- a/src/graph/node.js
+++ b/src/graph/node.js
@@ -81,6 +81,13 @@ export class Node {
      * @type {Map<string, *>}
      */
     this.data = new Map();
+
+    /**
+     * Css classes associated with this note node.
+     * @type {!Array<string>}
+     * @protected
+     */
+    this.classes_ = ['node'];
   }
 
 
@@ -97,7 +104,7 @@ export class Node {
    * @return {!Array<string>} The css class names associated with this node.
    */
   getClasses() {
-    return ['node'];
+    return this.classes_;
   }
 
   /**

--- a/src/graph/node.js
+++ b/src/graph/node.js
@@ -11,6 +11,8 @@
 'use strict';
 
 
+import * as PIXI from "pixi.js";
+
 export class Node {
   /**
    * Constructs a node with the given id.
@@ -58,5 +60,35 @@ export class Node {
      * @type {number|null}
      */
     this.fy = null;
+
+    /**
+     * The pixi container holding all of the node's rendered elements.
+     * @type {PIXI.Container}
+     * @private
+     */
+    this.container_ = new PIXI.Container();
+    this.container_.zIndex = 1;
+
+    /**
+     * A data object that can be used to store extra data about a node.
+     * @type {Map<string, *>}
+     */
+    this.data = new Map();
+  }
+
+
+  /**
+   * Returns the container which holds all of this node's rendered elements.
+   */
+  getContainer() {
+    return this.container_;
+  }
+
+  /**
+   * Disposes of this node.
+   */
+  destroy() {
+    this.container_.parent && this.container_.parent.removeChild(this.container_);
+    this.container_.destroy({children: true});
   }
 }

--- a/src/graph/node.js
+++ b/src/graph/node.js
@@ -70,6 +70,8 @@ export class Node {
 
     /**
      * The pixi container holding all of the node's rendered elements.
+     * The node must own the container to allow for the builder and layout to
+     * bind mouse events to it.
      * @type {!PIXI.Container}
      * @private
      */

--- a/src/graph/node.js
+++ b/src/graph/node.js
@@ -78,12 +78,6 @@ export class Node {
     this.container_.sortableChildren = true;
 
     /**
-     * A data object that can be used to store extra data about a node.
-     * @type {Map<string, *>}
-     */
-    this.data = new Map();
-
-    /**
      * Css classes associated with this node.
      * @type {!Array<string>}
      * @protected

--- a/src/graph/nonexisting-note-node.js
+++ b/src/graph/nonexisting-note-node.js
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2020 Obsidian Better Graph View
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Class for a model of a non-existing note node in a graph.
+ * @author bekawestberg@gmail.com (Beka Westberg)
+ */
+'use strict';
+
+import {Node} from './node';
+import {FOLDERS_PREFIX} from '../utils/constants';
+import {linkCacheToId} from '../utils/ids';
+
+export class NonExistingNoteNode extends Node {
+  /**
+   * Constructs a node representing a non-existing note.
+   * @param {LinkCache}linkCache The link cache representing the link.
+   */
+  constructor(linkCache) {
+    super(linkCacheToId(linkCache), linkCache.link);
+
+    this.classes_.push('non-existing-note');
+
+    const folders = linkCache.link.split('/');
+    for (let i = 0; i < folders.length - 1; i++) {
+      this.classes_.push(FOLDERS_PREFIX + folders[i]);
+    }
+  }
+}

--- a/src/graph/nonexisting-note-node.js
+++ b/src/graph/nonexisting-note-node.js
@@ -10,9 +10,11 @@
  */
 'use strict';
 
+
 import {Node} from './node';
 import {FOLDERS_PREFIX} from '../utils/constants';
 import {linkCacheToId} from '../utils/ids';
+
 
 export class NonExistingNoteNode extends Node {
   /**

--- a/src/graph/note-node.js
+++ b/src/graph/note-node.js
@@ -5,16 +5,17 @@
  */
 
 /**
- * @fileoverview Class for a model of a node in a graph.
+ * @fileoverview Class for a model of a note node in a graph.
  * @author bekawestberg@gmail.com (Beka Westberg)
  */
 'use strict';
 
 
-import {Node} from "./node";
+import {Node} from './node';
 import {TFile} from 'obsidian';
 import {MetadataCache} from 'obsidian';
 import {TAGS_PREFIX, FOLDERS_PREFIX} from '../utils/constants';
+import {fileToId} from '../utils/ids';
 
 
 export class NoteNode extends Node {
@@ -24,15 +25,9 @@ export class NoteNode extends Node {
    * @param {!MetadataCache} metadataCache The metadata cache.
    */
   constructor(file, metadataCache) {
-    const id = metadataCache.fileToLinktext(file, file.path);
-    super(id, file.basename);
+    super(fileToId(file, metadataCache), file.basename);
 
-    /**
-     * Css classes associated with this note node. Includes tags and folders.
-     * @type {!Array<string>}
-     * @private
-     */
-    this.classes_ = [];
+    this.classes_.push('existing-note');
 
     const cache = metadataCache.getFileCache(file);
     if (cache.tags) {
@@ -44,13 +39,5 @@ export class NoteNode extends Node {
     for (let i = 0; i < folders.length - 1; i++) {
       this.classes_.push(FOLDERS_PREFIX + folders[i]);
     }
-  }
-
-  /**
-   * Returns the css class names associated with this node.
-   * @return {!Array<string>} The css class names associated with this node.
-   */
-  getClasses() {
-    return [...super.getClasses(), ...this.classes_];
   }
 }

--- a/src/graph/note-node.js
+++ b/src/graph/note-node.js
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2020 Obsidian Better Graph View
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Class for a model of a node in a graph.
+ * @author bekawestberg@gmail.com (Beka Westberg)
+ */
+'use strict';
+
+
+import {Node} from "./node";
+import {TFile} from 'obsidian';
+import {MetadataCache} from 'obsidian';
+import {TAGS_PREFIX, FOLDERS_PREFIX} from '../utils/constants';
+
+
+export class NoteNode extends Node {
+  /**
+   * Constructs a node representing an existing note.
+   * @param {!TFile} file The note.
+   * @param {!MetadataCache} metadataCache The metadata cache.
+   */
+  constructor(file, metadataCache) {
+    const id = metadataCache.fileToLinktext(file, file.path);
+    super(id, file.basename);
+
+    /**
+     * Css classes associated with this note node. Includes tags and folders.
+     * @type {!Array<string>}
+     * @private
+     */
+    this.classes_ = [];
+
+    const cache = metadataCache.getFileCache(file);
+    if (cache.tags) {
+      cache.tags.forEach(tagCache =>
+          this.classes_.push(TAGS_PREFIX + tagCache.tag.substring(1)));
+    }
+
+    const folders = file.path.split('/');
+    for (let i = 0; i < folders.length - 1; i++) {
+      this.classes_.push(FOLDERS_PREFIX + folders[i]);
+    }
+  }
+
+  /**
+   * Returns the css class names associated with this node.
+   * @return {!Array<string>} The css class names associated with this node.
+   */
+  getClasses() {
+    return [...super.getClasses(), ...this.classes_];
+  }
+}

--- a/src/graph/tag-node.js
+++ b/src/graph/tag-node.js
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2020 Obsidian Better Graph View
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Class for a model of a tag node in a graph.
+ * @author bekawestberg@gmail.com (Beka Westberg)
+ */
+'use strict';
+
+
+import {Node} from './node';
+import {TAGS_PREFIX} from '../utils/constants';
+import {tagToId} from '../utils/ids';
+
+
+export class TagNode extends Node {
+  /**
+   * Constructs a node representing a tag.
+   * @param {string} tag The tag this node is representing.
+   */
+  constructor(tag) {
+    super(tagToId(tag), tag);
+
+    this.classes_.push('tag');
+    this.classes_.push(TAGS_PREFIX + tag.substring(1));
+  }
+}

--- a/src/renderers/i-renderer.js
+++ b/src/renderers/i-renderer.js
@@ -28,7 +28,7 @@ export class Renderer {
     /**
      * The pixi application that will handle rendering our graph.
      * @type {!PIXI.Application}
-     * @private
+     * @protected
      */
     this.pixi_ = pixiApp;
 
@@ -36,7 +36,7 @@ export class Renderer {
      * The viewport that all children created by the renderer should be added
      * to. This allows for scrolling and zooming.
      * @type {!Viewport}
-     * @private
+     * @protected
      */
     this.viewport_ = viewport;
   }

--- a/src/renderers/simple.js
+++ b/src/renderers/simple.js
@@ -114,7 +114,7 @@ export class SimpleRenderer extends Renderer {
           wordWrapWidth: WORD_WRAP,
         });
         text.anchor.set(.5, 0);
-        this.updateText_(text);
+        this.updateText_(1, text);
         container.addChild(text);
       }
     });
@@ -157,7 +157,7 @@ export class SimpleRenderer extends Renderer {
 
         const text = container.getChildAt(1);
         text.text = node.displayText;
-        text.setTransform(0, radius);
+        text.position.set(0, radius);
       }
     });
   }
@@ -189,9 +189,9 @@ export class SimpleRenderer extends Renderer {
       return;
     }
 
-    this.graph_.getNodes().forEach((node) => {
+    this.graph_.forEachNode((node) => {
       const container = node.getContainer();
-      this.updateText_(container.getChildAt(1));
+      this.updateText_(this.oldScale_, container.getChildAt(1));
     });
     this.oldScale_ = this.viewport_.scaled;
   }
@@ -199,13 +199,12 @@ export class SimpleRenderer extends Renderer {
   /**
    * Updates the size an opacity of the given text element.
    * @param {!PIXI.Text} text The text element to update.
+   * @param {number} oldScale The old scale we are changing from.
    * @private
    */
-  updateText_(text) {
+  updateText_(oldScale, text) {
     const scale = this.viewport_.scaled;
-    const xScale = text.scale.x * this.oldScale_ / scale;
-    const yScale = text.scale.y * this.oldScale_ / scale;
-    text.setTransform(text.x, text.y, xScale, yScale);
+    text.scale.set(text.scale.x * oldScale / scale);
 
     text.alpha = Math.min(
         Math.max(scale - MIN_TEXT_SCALE, 0) /

--- a/src/renderers/simple.js
+++ b/src/renderers/simple.js
@@ -19,174 +19,72 @@ import * as PIXI from 'pixi.js';
 
 export class SimpleRenderer extends Renderer {
   /**
-   * Constructs the simple renderer. This render is meant to emulate obsidian's
-   * default renderer.
-   * @param {!PIXI.Application} pixiApp The pixi application handling our render.
-   * @param {!Viewport} viewport The viewport this renderer will render to.
-   */
-  constructor(pixiApp, viewport) {
-    super(pixiApp, viewport);
-
-    /**
-     * Map of node ids to containers (which render the nodes).
-     * @type {!Map<string, PIXI.Container>}
-     * @private
-     */
-    this.nodeContainersMap_ = new Map();
-
-    this.nodeDataMap_ = new Map();
-
-    /**
-     * Map of edge ids to containers (which render the edge).
-     * @type {!Map<string, PIXI.Container>}
-     * @private
-     */
-    this.edgeContainersMap_ = new Map();
-  }
-
-  /**
    * Called when the layout of the graph changes. Redraws all of the positions
    * of the nodes and edges.
    * @param {!Graph} graph The graph to render.
    */
   onLayoutUpdate(graph) {
-    this.clearOldNodes_(graph);
-    this.addNodes_(graph);
+    this.attachNodesAndEdges_(graph);
     this.updateNodes_(graph);
-    this.clearOldEdges_(graph);
     this.updateEdges_(graph);
   }
 
   /**
-   * Removes any rendered nodes that are not in the nodes list.
+   * Adds any node/edge containers to the viewport that haven't been added.
    * @param {!Graph} graph The current graph.
    * @private
    */
-  clearOldNodes_(graph) {
-    const nodesInGraph = new Set();
-    graph.getNodes().forEach(node => nodesInGraph.add(node.id));
-    for (const [id, container] of this.nodeContainersMap_) {
-      if (!nodesInGraph.has(id)) {
-        this.viewport_.removeChild(container);
-        container.destroy({children: true});
-        this.nodeContainersMap_.delete(id);
-        this.nodeDataMap_.delete(id);
+  attachNodesAndEdges_(graph) {
+    const addContainer = (elem) => {
+      const container = elem.getContainer();
+      if (!container.parent) {
+        this.viewport_.addChild(container);
+        const graphics = new PIXI.Graphics();
+        container.addChild(graphics);
       }
-    }
+    };
+    graph.getNodes().forEach(addContainer);
+    graph.getEdges().forEach(addContainer);
   }
 
   /**
-   * Adds any nodes in the nodes list that are not currently rendered.
-   * @param {!Graph} graph The current graph.
-   * @private
-   */
-  addNodes_(graph) {
-    graph.getNodes().forEach((node) => {
-      if (this.nodeContainersMap_.has(node.id)) {
-        return;
-      }
-      const container = new PIXI.Container();
-      container.zIndex = 1;
-      const degree = graph.degree(node.id);
-      const radius = 4 * (1 + Math.log10(Math.max(degree - 5, 1)));
-      const circle = new PIXI.Graphics();
-      circle.beginFill(0x666666);
-      circle.drawCircle(0, 0, radius);
-      circle.endFill();
-
-      this.viewport_.addChild(container);
-      container.addChild(circle);
-      this.nodeContainersMap_.set(node.id, container);
-      this.nodeDataMap_.set(node.id, {degree: degree});
-    })
-  }
-
-  /**
-   * Updates the positions and colors of all of the rendered nodes to match the
-   * data in the graph model.
+   * Redraws any nodes that need to be redrawn, and updates their positions.
    * @param {!Graph} graph The current graph.
    * @private
    */
   updateNodes_(graph) {
     graph.getNodes().forEach((node) => {
-      const container = this.nodeContainersMap_.get(node.id);
+      const container = node.getContainer();
       container.setTransform(node.x, node.y);
 
       const degree = graph.degree(node.id);
-      const data = this.nodeDataMap_.get(node.id);
-      if (data.degree != degree) {
+      if (node.data.get('degree') != degree) {
         const radius = 4 * (1 + Math.log10(Math.max(degree - 5, 1)));
         const circle = container.getChildAt(0);
         circle.clear();
         circle.beginFill(0x666666);
         circle.drawCircle(0, 0, radius);
         circle.endFill();
-        data.degree = degree;
+        node.data.set('degree', degree);
       }
-    })
+    });
   }
 
   /**
-   * Removes any rendered edges that are not in the edges list.
-   * @param {!Graph} graph The current graph.
-   * @private
-   */
-  clearOldEdges_(graph) {
-    const edgesInGraph = new Set();
-    graph.getEdges().forEach(edge => edgesInGraph.add(edge.id));
-    for (const [id, container] of this.edgeContainersMap_) {
-      if (!edgesInGraph.has(id)) {
-        this.viewport_.removeChild(container);
-        container.destroy({children: true});
-        this.edgeContainersMap_.delete(id);
-      }
-    }
-  }
-
-  /**
-   * Adds any edges in the edge list that are not currently rendered, and
-   * updates all of the rendered edges to match the data in the graph model.
+   * Redraws edges to properly connect the updated nodes.
    * @param {!Graph} graph The current graph.
    * @private
    */
   updateEdges_(graph) {
     graph.getEdges().forEach((edge) => {
-      if (!this.edgeContainersMap_.has(edge.id)) {
-        this.addEdge_(edge);
-      }
-      this.layoutEdge_(edge, this.edgeContainersMap_.get(edge.id), graph);
-    })
-  }
+      const sourceNode = graph.getNode(edge.getSourceId());
+      const targetNode = graph.getNode(edge.getTargetId());
 
-  /**
-   * Creates a container and graphics element for the given edge.
-   * @param {!Edge} edge The edge to create a PIXI element for.
-   * @private
-   */
-  addEdge_(edge) {
-    const container = new PIXI.Container();
-    const line = new PIXI.Graphics();
-    this.viewport_.addChild(container);
-    container.addChild(line);
-    this.edgeContainersMap_.set(edge.id, container);
-  }
-
-  /**
-   * Updates the given container to draw a line between the two nodes identified
-   * by the given edge.
-   * @param {!Edge} edge The model of the edge to layout.
-   * @param {!PIXI.Container} container The container to layout.
-   * @param {!Graph} graph The current graph.
-   * @private
-   */
-  layoutEdge_(edge, container, graph) {
-    const sourceNode = graph.getNode(edge.getSourceId());
-    const targetNode = graph.getNode(edge.getTargetId());
-
-    const line = container.getChildAt(0);
-    line.clear();
-    line.lineStyle(1, 0xcccccc, 1);
-    line.moveTo(sourceNode.x, sourceNode.y);
-    line.lineTo(targetNode.x, targetNode.y);
+      const line = edge.getContainer().getChildAt(0);
+      line.clear();
+      line.lineStyle(1, 0xcccccc, 1);
+      line.moveTo(sourceNode.x, sourceNode.y);
+      line.lineTo(targetNode.x, targetNode.y);
+    });
   }
 }

--- a/src/renderers/simple.js
+++ b/src/renderers/simple.js
@@ -15,6 +15,8 @@
 import {Renderer} from './i-renderer';
 import {Graph} from '../graph/graph';
 import * as PIXI from 'pixi.js';
+import {getStyle} from '../utils/css-cache';
+import {rgbStringToHex} from "../utils/utils";
 
 
 /**
@@ -139,9 +141,16 @@ export class SimpleRenderer extends Renderer {
       if (node.data.get('degree') != degree) {
         const radius = MIN_RADIUS * (1 + Math.log10(
             Math.max(degree - IGNORED_CONNECTIONS, 1)));
+        const cssStyle = getStyle(node.getClasses());
+        const fillColor = rgbStringToHex(cssStyle.backgroundColor);
+        const borderColor = rgbStringToHex(cssStyle.borderColor);
+        const borderWidth = parseInt(cssStyle.borderWidth.substring(
+            0, cssStyle.borderWidth.length - 2));
+
         const circle = container.getChildAt(0);
         circle.clear();
-        circle.beginFill(0x666666);
+        circle.beginFill(fillColor);
+        circle.lineStyle(borderWidth, borderColor, 1, 0);
         circle.drawCircle(0, 0, radius);
         circle.endFill();
         node.data.set('degree', degree);

--- a/src/renderers/simple.js
+++ b/src/renderers/simple.js
@@ -17,13 +17,78 @@ import {Graph} from '../graph/graph';
 import * as PIXI from 'pixi.js';
 
 
+/**
+ * The minimum scale where we start being able to see the text.
+ * @type {number}
+ */
+const MIN_TEXT_SCALE = 1.8;
+
+/**
+ * The text scale at and beyond which text is at full opacity.
+ * @type {number}
+ */
+const MAX_TEXT_SCALE = 2.2;
+
+/**
+ * The text font size (not related to screen size).
+ * @type {number}
+ */
+const TEXT_SIZE = 14;
+
+/**
+ * The number of characters to start word wrapping at.
+ * @type {number}
+ */
+const WORD_WRAP = 200;
+
+/**
+ * The minimum radius of a node in the graph.
+ * @type {number}
+ */
+const MIN_RADIUS = 4;
+
+/**
+ * The number of connections to ignore before we start scaling the node based
+ * on the number of connections.
+ * @type {number}
+ */
+const IGNORED_CONNECTIONS = 5;
+
 export class SimpleRenderer extends Renderer {
+  /**
+   * Constructs a renderer instance given the PIXI Application instance.
+   * @param {!PIXI.Application} pixiApp The pixi application handling our
+   *     render.
+   * @param {!Viewport} viewport The viewport this renderer will render to.
+   */
+  constructor(pixiApp, viewport) {
+    super(pixiApp, viewport);
+
+
+    /**
+     * The graph being rendered.
+     * @type {Graph|null}
+     * @private
+     */
+    this.graph_ = null;
+
+    /**
+     * The most recent scale value for the viewport.
+     * @type {number}
+     * @private
+     */
+    this.oldScale_ = this.viewport_.scaled;
+
+    this.viewport_.on('zoomed', this.updateTexts_.bind(this));
+  }
+
   /**
    * Called when the layout of the graph changes. Redraws all of the positions
    * of the nodes and edges.
    * @param {!Graph} graph The graph to render.
    */
   onLayoutUpdate(graph) {
+    this.graph_ = graph;
     this.attachNodesAndEdges_(graph);
     this.updateNodes_(graph);
     this.updateEdges_(graph);
@@ -35,16 +100,29 @@ export class SimpleRenderer extends Renderer {
    * @private
    */
   attachNodesAndEdges_(graph) {
-    const addContainer = (elem) => {
-      const container = elem.getContainer();
+    graph.getNodes().forEach((node) => {
+      const container = node.getContainer();
       if (!container.parent) {
         this.viewport_.addChild(container);
-        const graphics = new PIXI.Graphics();
-        container.addChild(graphics);
+        container.addChild(new PIXI.Graphics());
+        const text = new PIXI.Text('', {
+          fontSize: TEXT_SIZE,
+          align: 'center',
+          wordWrap: true,
+          wordWrapWidth: WORD_WRAP,
+        });
+        text.anchor.set(.5, 0);
+        this.updateText_(text);
+        container.addChild(text);
       }
-    };
-    graph.getNodes().forEach(addContainer);
-    graph.getEdges().forEach(addContainer);
+    });
+    graph.getEdges().forEach((edge) => {
+      const container = edge.getContainer();
+      if (!container.parent) {
+        this.viewport_.addChild(container);
+        container.addChild(new PIXI.Graphics());
+      }
+    });
   }
 
   /**
@@ -59,13 +137,18 @@ export class SimpleRenderer extends Renderer {
 
       const degree = graph.degree(node.id);
       if (node.data.get('degree') != degree) {
-        const radius = 4 * (1 + Math.log10(Math.max(degree - 5, 1)));
+        const radius = MIN_RADIUS * (1 + Math.log10(
+            Math.max(degree - IGNORED_CONNECTIONS, 1)));
         const circle = container.getChildAt(0);
         circle.clear();
         circle.beginFill(0x666666);
         circle.drawCircle(0, 0, radius);
         circle.endFill();
         node.data.set('degree', degree);
+
+        const text = container.getChildAt(1);
+        text.text = node.displayText;
+        text.setTransform(0, radius);
       }
     });
   }
@@ -86,5 +169,37 @@ export class SimpleRenderer extends Renderer {
       line.moveTo(sourceNode.x, sourceNode.y);
       line.lineTo(targetNode.x, targetNode.y);
     });
+  }
+
+  /**
+   * Updates the size and opacity of all of the text elements.
+   * @private
+   */
+  updateTexts_() {
+    if (!this.graph_) {
+      return;
+    }
+
+    this.graph_.getNodes().forEach((node) => {
+      const container = node.getContainer();
+      this.updateText_(container.getChildAt(1));
+    });
+    this.oldScale_ = this.viewport_.scaled;
+  }
+
+  /**
+   * Updates the size an opacity of the given text element.
+   * @param {!PIXI.Text} text The text element to update.
+   * @private
+   */
+  updateText_(text) {
+    const scale = this.viewport_.scaled;
+    const xScale = text.scale.x * this.oldScale_ / scale;
+    const yScale = text.scale.y * this.oldScale_ / scale;
+    text.setTransform(text.x, text.y, xScale, yScale);
+
+    text.alpha = Math.min(
+        Math.max(scale - MIN_TEXT_SCALE, 0) /
+        (MAX_TEXT_SCALE - MIN_TEXT_SCALE), 100);
   }
 }

--- a/src/renderers/simple.js
+++ b/src/renderers/simple.js
@@ -75,6 +75,13 @@ export class SimpleRenderer extends Renderer {
     this.graph_ = null;
 
     /**
+     * A map of nodes to their latest degree measurements.
+     * @type {!WeakMap<!Node, number>}
+     * @private
+     */
+    this.nodeDegrees_ = new WeakMap();
+
+    /**
      * The most recent scale value for the viewport.
      * @type {number}
      * @private
@@ -153,7 +160,7 @@ export class SimpleRenderer extends Renderer {
       container.setTransform(node.x, node.y);
 
       const degree = graph.degree(node.id);
-      if (node.data.get('degree') != degree) {
+      if (this.nodeDegrees_.get(node) != degree) {
         const radius = MIN_RADIUS * (1 + Math.log10(
             Math.max(degree - IGNORED_CONNECTIONS, 1)));
         const cssStyle = getStyle(node.getClasses());
@@ -168,7 +175,7 @@ export class SimpleRenderer extends Renderer {
         circle.lineStyle(borderWidth, borderColor, 1, 0);
         circle.drawCircle(0, 0, radius);
         circle.endFill();
-        node.data.set('degree', degree);
+        this.nodeDegrees_.set(node, degree);
 
         const text = container.getChildAt(1);
         text.text = node.displayText;

--- a/src/renderers/simple.js
+++ b/src/renderers/simple.js
@@ -107,15 +107,7 @@ export class SimpleRenderer extends Renderer {
       if (!container.parent) {
         this.viewport_.addChild(container);
         container.addChild(new PIXI.Graphics());
-        const text = new PIXI.Text('', {
-          fontSize: TEXT_SIZE,
-          align: 'center',
-          wordWrap: true,
-          wordWrapWidth: WORD_WRAP,
-        });
-        text.anchor.set(.5, 0);
-        this.updateText_(1, text);
-        container.addChild(text);
+        container.addChild(this.makeText_());
       }
     });
     graph.getEdges().forEach((edge) => {
@@ -125,6 +117,29 @@ export class SimpleRenderer extends Renderer {
         container.addChild(new PIXI.Graphics());
       }
     });
+  }
+
+  /**
+   * Creates a PIXI.text element, initializes it and returns it.
+   * @return {!PIXI.Text} The text element that has been created.
+   * @private
+   */
+  makeText_() {
+    const cssStyle = getStyle(['node']);
+    const color = rgbStringToHex(cssStyle.color);
+
+    const text = new PIXI.Text('', {
+      fontSize: TEXT_SIZE,
+      align: 'center',
+      wordWrap: true,
+      wordWrapWidth: WORD_WRAP,
+      fill: color,
+    });
+    text.zIndex = 1;
+    text.anchor.set(.5, 0);
+    this.updateText_(1, text);
+
+    return text;
   }
 
   /**
@@ -172,9 +187,12 @@ export class SimpleRenderer extends Renderer {
       const sourceNode = graph.getNode(edge.getSourceId());
       const targetNode = graph.getNode(edge.getTargetId());
 
+      const cssStyle = getStyle(edge.getClasses());
+      const fillColor = rgbStringToHex(cssStyle.backgroundColor);
+
       const line = edge.getContainer().getChildAt(0);
       line.clear();
-      line.lineStyle(1, 0xcccccc, 1);
+      line.lineStyle(1, fillColor, 1);
       line.moveTo(sourceNode.x, sourceNode.y);
       line.lineTo(targetNode.x, targetNode.y);
     });

--- a/src/renderers/simple.js
+++ b/src/renderers/simple.js
@@ -16,7 +16,7 @@ import {Renderer} from './i-renderer';
 import {Graph} from '../graph/graph';
 import * as PIXI from 'pixi.js';
 import {getStyle} from '../utils/css-cache';
-import {rgbStringToHex} from "../utils/utils";
+import {rgbStringToHex} from '../utils/color';
 
 
 /**

--- a/src/styles.css
+++ b/src/styles.css
@@ -12,3 +12,7 @@ body {
     width: 100%;
     height: 100%;
 }
+
+.node {
+    color: #666666;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,8 +1,3 @@
-/* Sets all the text color to red! */
-body {
-    color: red;
-}
-
 #graph-container-container {
     padding: 0;
 }
@@ -14,5 +9,24 @@ body {
 }
 
 .node {
-    color: #666666;
+    background-color: #888;
+    border: 0 solid #888;
+    color: black;
 }
+
+.node.non-existing-note {
+    background-color: #CFCFCF;
+}
+
+.node.tag {
+    background-color: #E0D3AF;
+}
+
+.node.attachment {
+    background-color: #83D4F4;
+}
+
+.edge {
+    background-color: #CFCFCF;
+}
+

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * @fileoverview File holds a bunch of little utility functions.
+ * @fileoverview File holds a bunch of color utility functions.
  * @author bekawestberg@gmail.com (Beka Westberg)
  */
 'use strict';

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -14,3 +14,4 @@ export const VIEW_TYPE_BETTER_GRAPH = 'beks_better_graph';
 export const VIEW_TYPE_GRAPH_SETTINGS = 'beks_graph_settings';
 export const TAGS_PREFIX = 't-';
 export const FOLDERS_PREFIX = 'f-';
+export const ATTACHMENTS_PREFIX = 'a-';

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -10,5 +10,7 @@
  */
 'use strict';
 
-export const VIEW_TYPE_BETTER_GRAPH = "beks_better_graph";
-export const VIEW_TYPE_GRAPH_SETTINGS = "beks_graph_settings";
+export const VIEW_TYPE_BETTER_GRAPH = 'beks_better_graph';
+export const VIEW_TYPE_GRAPH_SETTINGS = 'beks_graph_settings';
+export const TAGS_PREFIX = 't-';
+export const FOLDERS_PREFIX = 'f-';

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -10,6 +10,7 @@
  */
 'use strict';
 
+
 export const VIEW_TYPE_BETTER_GRAPH = 'beks_better_graph';
 export const VIEW_TYPE_GRAPH_SETTINGS = 'beks_graph_settings';
 export const TAGS_PREFIX = 't-';

--- a/src/utils/css-cache.js
+++ b/src/utils/css-cache.js
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2020 Obsidian Better Graph View
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview File handles computing styles for elements with various classes.
+ * @author bekawestberg@gmail.com (Beka Westberg)
+ */
+'use strict';
+
+
+/**
+ * A map of concatenated class names to CSSStyleDeclarations with those classes.
+ * @type {!Map<string, !CSSStyleDeclaration>}
+ * @private
+ */
+const elementMap_ = new Map();
+
+/**
+ * The container for all of our test elements.
+ * @type {Element|null}
+ * @private
+ */
+let testElementsContainer_ = null;
+
+/**
+ * Returns the style associated with the given class names and pseudo element.
+ * @param {!Array<string>} classNames An array of class names.
+ * @param {?string} pseudoElt A valid pseudo element such as ::before or ::after.
+ *     See the docs for more info: https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle
+ * @return {!CSSStyleDeclaration} The style associated with the given class
+ *     names and selector.
+ */
+export function getStyle(classNames, pseudoElt) {
+  init_();
+
+  classNames.sort();
+  const concatNames = classNames.join(' ');
+  const key = concatNames + pseudoElt;
+  if (elementMap_.has(key)) {
+    return elementMap_.get(key);
+  }
+  const elem = document.createElement('div');
+  elem.style.width = 0;
+  elem.style.height = 0;
+  elem.className = concatNames;
+  testElementsContainer_.appendChild(elem);
+  const style = getComputedStyle(elem, pseudoElt);
+  elementMap_.set(key, style);
+  return style;
+}
+
+function init_() {
+  if (!testElementsContainer_) {
+    testElementsContainer_ = document.createElement('div');
+    testElementsContainer_.setAttribute(
+        'id', 'better-graph-view-css-test-container');
+    document.body.append(testElementsContainer_);
+  }
+}

--- a/src/utils/ids.js
+++ b/src/utils/ids.js
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2020 Obsidian Better Graph View
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview File holds a bunch of utility functions for creating ids.
+ * @author bekawestberg@gmail.com (Beka Westberg)
+ */
+'use strict';
+
+
+/**
+ * Returns an id for the given file.
+ * @param {!TFile} file The file to get an id for.
+ * @param {!MetadataCache} metadataCache The metadata cache.
+ * @return {string} The created id.
+ */
+export function fileToId(file, metadataCache) {
+  return metadataCache.fileToLinktext(file, file.path);
+}
+
+/**
+ * Returns an id for the given link.
+ * @param {!LinkCache} linkCache The given link to get an id for.
+ * @return {string} The created id.
+ */
+export function linkCacheToId(linkCache) {
+  return linkCache.link;
+}
+
+/**
+ * Returns an id for the given tag.
+ * @param {string} tag The tag to get an id for.
+ * @return {string} The created id.
+ */
+export function tagToId(tag) {
+  return 'tag' + tag.substring(1);
+}
+
+/**
+ * Returns an id for the given attachment.
+ * @param {!EmbedCache} attachment The attachment to get an id for.
+ * @return {string} The created id.
+ */
+export function attachmentToId(attachment) {
+  return 'attachment' + attachment.link;
+}
+
+/**
+ * Returns an id for the given edge.
+ * @param {string} sourceId The id of the source node for the edge.
+ * @param {string} targetId The id of the target node for the edge.
+ * @return {string} The created id.
+ */
+export function getEdgeId(sourceId, targetId) {
+  return sourceId + '-to-' + targetId;
+}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2020 Obsidian Better Graph View
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview File holds a bunch of little utility functions.
+ * @author bekawestberg@gmail.com (Beka Westberg)
+ */
+'use strict';
+
+
+/**
+ * Converts a string of the form 'rgb(r, g, b)' to a hexadecimal string of the
+ * form '0xRRGGBB'.
+ * @param {string} rgbString The rgb string of the form 'rgb(r, g, b)'.
+ * @return {string} A hexadecimal string of the form '0xRRGGBB'.
+ */
+export function rgbStringToHex(rgbString) {
+  let color;
+  if (rgbString[3] == 'a') {
+    color = rgbString.match(
+        /^rgba\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$/i);
+  } else {
+    color = rgbString.match(
+        /^rgb\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$/i);
+  }
+  return '0x' + decToHex(color[1]) + decToHex(color[2]) + decToHex(color[3]);
+}
+
+/**
+ * Convert a decimal string to a 2 digit hexadecimal string.
+ * @param {string} decString The number string in decimal.
+ * @return {string} The number string in hexadecimal.
+ */
+function decToHex(decString) {
+  const hex = parseInt(decString).toString(16);
+  if (hex.length == 1) {
+    return '0' + hex;
+  }
+  return hex;
+}

--- a/src/views/better-graph.js
+++ b/src/views/better-graph.js
@@ -13,7 +13,7 @@
 
 // Obsidian imports
 import {ItemView, WorkspaceLeaf} from 'obsidian';
-import {VIEW_TYPE_BETTER_GRAPH, VIEW_TYPE_GRAPH_SETTINGS} from '../constants';
+import {VIEW_TYPE_BETTER_GRAPH, VIEW_TYPE_GRAPH_SETTINGS} from '../utils/constants';
 
 
 export class BetterGraphView extends ItemView {

--- a/src/views/graph-settings.js
+++ b/src/views/graph-settings.js
@@ -163,13 +163,15 @@ export class GraphSettingsView extends ItemView {
    * pixi viewport.
    */
   onGraphResize() {
+    window.viewport = this.viewport_;
     const container = this.betterGraphView_.getGraphContainer();
     const width = container.offsetWidth;
     const height = container.offsetHeight;
     this.pixi_.renderer.resize(width, height);
-    this.viewport_.screenWidth = width;
-    this.viewport_.screenHeight = height;
-    this.viewport_.moveCenter(width / 2, height / 2)
+    const view = this.viewport_;
+    view.screenWidth = width;
+    view.screenHeight = height;
+    view.moveCenter(0, 0);
   }
 
   /**

--- a/src/views/graph-settings.js
+++ b/src/views/graph-settings.js
@@ -19,7 +19,7 @@ import {
   ValueComponent
 } from 'obsidian';
 
-import {VIEW_TYPE_BETTER_GRAPH, VIEW_TYPE_GRAPH_SETTINGS} from "../constants";
+import {VIEW_TYPE_BETTER_GRAPH, VIEW_TYPE_GRAPH_SETTINGS} from '../utils/constants';
 
 import {Graph} from '../graph/graph';
 import {GraphBuilderRegistry} from '../graph-builders/graph-builders-registry';

--- a/src/views/graph-settings.js
+++ b/src/views/graph-settings.js
@@ -163,7 +163,6 @@ export class GraphSettingsView extends ItemView {
    * pixi viewport.
    */
   onGraphResize() {
-    window.viewport = this.viewport_;
     const container = this.betterGraphView_.getGraphContainer();
     const width = container.offsetWidth;
     const height = container.offsetHeight;


### PR DESCRIPTION
### Description

Adds a bunch of stuff to the simple renderer:
  * Sizing of nodes logarithmically based on degree.
  * Text labels for nodes.
  * Different types of nodes representing different types of things (notes, non-existing notes, tags, and attachments).
  * Coloring of nodes via css based on type information, folder path, and included tags (in the case of notes). Supports node color, border color, and border width.
  * Coloring of edges and labels via css.

### Testing

1) Coloring of nodes via type.
2) Coloring of nodes via tag.
3) Coloring of nodes via file path.
4) Coloring of text and edges.

Standard tests for graph builder settings to make sure I didn't break anything.
