### PR TITLE
Make the initial layout faster

### DIFF
--- a/src/layouts/i-layout.js
+++ b/src/layouts/i-layout.js
@@ -23,6 +23,14 @@ import {Graph} from '../graph/graph';
  */
 export class Layout extends Events {
   /**
+   * Constructs a Layout instance given the viewport.
+   * @param {!Viewport} viewport The viewport used for subscribing to move
+   *     events.
+   */
+  constructor(viewport) {
+    super();
+  }
+  /**
    * Subscribes this layout to the given graph builder.
    * @param {GraphBuilder} graphBuilder The graph builder to subscribe to.
    */

--- a/src/renderers/simple.js
+++ b/src/renderers/simple.js
@@ -58,7 +58,7 @@ const IGNORED_CONNECTIONS = 5;
 
 export class SimpleRenderer extends Renderer {
   /**
-   * Constructs a renderer instance given the PIXI Application instance.
+   * Constructs a renderer instance given the PIXI Application and viewport.
    * @param {!PIXI.Application} pixiApp The pixi application handling our
    *     render.
    * @param {!Viewport} viewport The viewport this renderer will render to.
@@ -161,6 +161,8 @@ export class SimpleRenderer extends Renderer {
 
       const degree = graph.degree(node.id);
       if (this.nodeDegrees_.get(node) != degree) {
+        this.nodeDegrees_.set(node, degree);
+
         const radius = MIN_RADIUS * (1 + Math.log10(
             Math.max(degree - IGNORED_CONNECTIONS, 1)));
         const cssStyle = getStyle(node.getClasses());
@@ -175,7 +177,8 @@ export class SimpleRenderer extends Renderer {
         circle.lineStyle(borderWidth, borderColor, 1, 0);
         circle.drawCircle(0, 0, radius);
         circle.endFill();
-        this.nodeDegrees_.set(node, degree);
+
+        container.hitArea = new PIXI.Circle(0, 0, radius);
 
         const text = container.getChildAt(1);
         text.text = node.displayText;

--- a/src/views/graph-settings.js
+++ b/src/views/graph-settings.js
@@ -203,7 +203,7 @@ export class GraphSettingsView extends ItemView {
     this.onGraphResize();
 
     this.selectedRenderer_ = new SimpleRenderer(this.pixi_, this.viewport_);
-    this.selectedLayout_ = new ForceDirectedLayout();
+    this.selectedLayout_ = new ForceDirectedLayout(this.viewport_);
 
     // TOOD: Unify with updateSelectedBuilder_ below.
     this.selectedBuilder_.setGraph(this.graph_);


### PR DESCRIPTION
### Description

Makes getting to a good layout state happen faster.

Also makes it so that the force simulation stops simulating when we zoom/pan so that that is less choppy.

And sets the container's hit area to just match the node so that it is easier to pan the zoomed out graph.