### PR TITLE
Fix garbage collection

### DIFF
--- a/src/layouts/force-directed.js
+++ b/src/layouts/force-directed.js
@@ -171,4 +171,12 @@ export class ForceDirectedLayout extends Layout {
       this.simulation_.alphaTarget(0);
     }
   }
+
+  /**
+   * Disposes of this layout.
+   */
+  dispose() {
+    super.dispose();
+    this.simulation_.stop();
+  }
 }

--- a/src/layouts/i-layout.js
+++ b/src/layouts/i-layout.js
@@ -29,13 +29,29 @@ export class Layout extends Events {
    */
   constructor(viewport) {
     super();
+
+    /**
+     * The graph builder associated with this layout.
+     * @type {GraphBuilder|null}
+     * @private
+     */
+    this.graphBuilder_ = null;
+
+    /**
+     * The event ref associated with the grpah builder structure update event.
+     * @type {EventRef|null}
+     * @private
+     */
+    this.updateRef_ = null;
   }
   /**
    * Subscribes this layout to the given graph builder.
-   * @param {GraphBuilder} graphBuilder The graph builder to subscribe to.
+   * @param {!GraphBuilder} graphBuilder The graph builder to subscribe to.
    */
   setGraphBuilder(graphBuilder) {
-    graphBuilder.on('structure-update', this.onGraphUpdate, this);
+    this.graphBuilder_ = graphBuilder;
+    this.updateRef_ =
+        graphBuilder.on('structure-update', this.onGraphUpdate, this);
   }
 
   /**
@@ -59,5 +75,13 @@ export class Layout extends Events {
     } else {
       throw 'Unknown layout event: "' + name + '".';
     }
+  }
+
+  /**
+   * Disposes of this layout. Gets rid of any references (ie for events) that
+   * might keep this from being disposed.
+   */
+  dispose() {
+    this.graphBuilder_.offref(this.updateRef_);
   }
 }

--- a/src/layouts/i-layout.js
+++ b/src/layouts/i-layout.js
@@ -49,6 +49,9 @@ export class Layout extends Events {
    * @param {!GraphBuilder} graphBuilder The graph builder to subscribe to.
    */
   setGraphBuilder(graphBuilder) {
+    if (this.graphBuilder_ && this.updateRef_) {
+      this.graphBuilder_.offref(this.updateRef_);
+    }
     this.graphBuilder_ = graphBuilder;
     this.updateRef_ =
         graphBuilder.on('structure-update', this.onGraphUpdate, this);

--- a/src/renderers/i-renderer.js
+++ b/src/renderers/i-renderer.js
@@ -39,14 +39,29 @@ export class Renderer {
      * @protected
      */
     this.viewport_ = viewport;
+
+    /**
+     * The layout associated with this renderer.
+     * @type {Layout|null}
+     * @private
+     */
+    this.layout_ = null;
+
+    /**
+     * The event ref associated with the layout update event.
+     * @type {EventRef|null}
+     * @private
+     */
+    this.updateRef_ = null;
   }
 
   /**
    * Subscribes this renderer to the given graph layout.
-   * @param {Layout} layout
+   * @param {!Layout} layout The layout associated with this renderer.
    */
   setLayout(layout) {
-    layout.on('layout-update', this.onLayoutUpdate, this);
+    this.layout_ = layout;
+    this.updateRef_ = layout.on('layout-update', this.onLayoutUpdate, this);
   }
 
   /**
@@ -54,4 +69,12 @@ export class Renderer {
    * @param {Graph} graph The graph that has just been updated.
    */
   onLayoutUpdate(graph) {}
+
+  /**
+   * Disposes of this renderer. Gets rid of any references (ie for events) that
+   * might keep this from being disposed.
+   */
+  dispose() {
+    this.layout_.offref(this.updateRef_);
+  }
 }

--- a/src/renderers/i-renderer.js
+++ b/src/renderers/i-renderer.js
@@ -60,6 +60,9 @@ export class Renderer {
    * @param {!Layout} layout The layout associated with this renderer.
    */
   setLayout(layout) {
+    if (this.layout_ && this.updateRef_) {
+      this.layout_.offref(this.updateRef_);
+    }
     this.layout_ = layout;
     this.updateRef_ = layout.on('layout-update', this.onLayoutUpdate, this);
   }

--- a/src/views/graph-settings.js
+++ b/src/views/graph-settings.js
@@ -161,8 +161,9 @@ export class GraphSettingsView extends ItemView {
   /**
    * Called when the better graph view resizes. Updates the size of pixi and the
    * pixi viewport.
+   * @private
    */
-  onGraphResize() {
+  onGraphResize_() {
     const container = this.betterGraphView_.getGraphContainer();
     const width = container.offsetWidth;
     const height = container.offsetHeight;
@@ -174,13 +175,29 @@ export class GraphSettingsView extends ItemView {
   }
 
   /**
+   * Cleanes up references to allow for garbage collection when the graph view
+   * is closed.
+   * @private
+   */
+  onGraphClose_() {
+    this.graph_.clear();
+    this.selectedRenderer_.dispose();
+    this.selectedRenderer_ = null;
+    this.selectedLayout_.dispose();
+    this.selectedLayout_ = null;
+    this.pixi_.destroy(true, true);
+    this.pixi_ = null;
+  }
+
+  /**
    * Sets the graph associated with this graph settings view.
    * @param {BetterGraphView} graphView The better graph view.
    */
   setGraphView(graphView) {
     this.betterGraphView_ = graphView;
     // TODO: Find a better fix than this hack.
-    graphView.onResize = this.onGraphResize.bind(this);
+    graphView.onResize = this.onGraphResize_.bind(this);
+    graphView.onClose = this.onGraphClose_.bind(this);
 
     const container = graphView.getGraphContainer();
     this.pixi_ = new PIXI.Application({
@@ -200,7 +217,7 @@ export class GraphSettingsView extends ItemView {
     this.viewport_
         .drag()
         .wheel({smooth: 10});
-    this.onGraphResize();
+    this.onGraphResize_();
 
     this.selectedRenderer_ = new SimpleRenderer(this.pixi_, this.viewport_);
     this.selectedLayout_ = new ForceDirectedLayout(this.viewport_);


### PR DESCRIPTION
### Description

If you reopened the better graph view after closing it you would get errors because references to the previous better graph view were not being disposed by the graph settings view. This disposes of those settings.

Also fixes old event listeners not getting removed when we have to re-initialize the layout and render to be associated with the new graph builder.

### Testing

Tested opening and closing the better graph view.

Also tested switching between different graph builders.