### PR TITLE
Add animation when hovering over a node

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "d3-force": "^2.1.1",
+    "gsap": "^3.5.1",
     "pixi-viewport": "^4.18.1",
     "pixi.js": "^5.3.3"
   }

--- a/src/renderers/simple.js
+++ b/src/renderers/simple.js
@@ -106,14 +106,36 @@ export class SimpleRenderer extends Renderer {
      */
     this.nodeDegrees_ = new WeakMap();
 
+    /**
+     * A map of nodes to maps of strings to event listeners on those nodes.
+     * @type {!WeakMap<!Node, !Map<string, !Function>>}
+     * @private
+     */
     this.nodeWatchers_ = new WeakMap();
 
+    /**
+     * A set of all nodes that are currently being hovered. Should always have
+     * a length of 1, but just in case I'm using a set.
+     * @type {!WeakSet<!Node>}
+     * @private
+     */
     this.hoveredNodes_ = new WeakSet();
 
+    /**
+     * The main layer that all of the node and edge containers should live on.
+     * @type {!PIXI.Container}
+     * @private
+     */
     this.mainLayer_ = new PIXI.Container();
     this.mainLayer_.sortableChildren = true;
     this.viewport_.addChild(this.mainLayer_);
 
+    /**
+     * The highlight layer than any nodes which are currently being selected
+     * live on.
+     * @type {!PIXI.Container}
+     * @private
+     */
     this.highlightedLayer_ = new PIXI.Container();
     this.highlightedLayer_.sortableChildren = true;
     this.highlightedLayer_.zIndex = 1;


### PR DESCRIPTION
### Description

Adds an animation when you hover over a node so that you can get info about it.
1) Displays the text at a larger size than normal and full opacity, regardless of zoom.
2) Darkens connected edges so you can see connected nodes.
3) Puts connected nodes and edges on a higher layer so they can be seen above other info.
3) Makes everything else in the graph more transparent.

### Testing

There are some bugs with hovering and unhovering too quickly, but I'm satisfied enough with this to merge it.