### PR TITLE
Make rendering more efficient

### DIFF
--- a/src/graph/edge.js
+++ b/src/graph/edge.js
@@ -64,7 +64,7 @@ export class Edge {
    * @return {string} The id of the source node.
    */
   getSourceId() {
-    return typeof this.source == 'string' ? this.source : this.source.id;
+    return this.source.id || this.source;
   }
 
   /**
@@ -72,7 +72,7 @@ export class Edge {
    * @return {string} The id of the target node.
    */
   getTargetId() {
-    return typeof this.target == 'string' ? this.target : this.target.id;
+    return this.target.id || this.target;
   }
 
   /**

--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -164,7 +164,7 @@ export class Graph {
    *     not exist.
    */
   getEdge(edgeId) {
-    return this.edgesMap_.get(nodeId);
+    return this.edgesMap_.get(edgeId);
   }
 
   /**

--- a/src/layouts/force-directed.js
+++ b/src/layouts/force-directed.js
@@ -98,9 +98,7 @@ export class ForceDirectedLayout extends Layout {
     // Nodes must be updated before links.
     this.simulation_.nodes(graph.getNodes());
     this.linkForce_.links(this.graph_.getEdges());
-    // this.simulation_.tick(1);
-    // this.onSimulationUpdate_();
-    // this.simulation_.tick(100);
+    this.simulation_.tick(100);
     this.simulation_.alpha(1).restart();
   }
 

--- a/src/layouts/force-directed.js
+++ b/src/layouts/force-directed.js
@@ -98,7 +98,9 @@ export class ForceDirectedLayout extends Layout {
     // Nodes must be updated before links.
     this.simulation_.nodes(graph.getNodes());
     this.linkForce_.links(this.graph_.getEdges());
-    this.simulation_.tick(100);
+    // this.simulation_.tick(1);
+    // this.onSimulationUpdate_();
+    // this.simulation_.tick(100);
     this.simulation_.alpha(1).restart();
   }
 

--- a/src/layouts/force-directed.js
+++ b/src/layouts/force-directed.js
@@ -71,8 +71,8 @@ export class ForceDirectedLayout extends Layout {
 
     this.simulation_
         .force('link', this.linkForce_)
-        .force('x', forceX(0).strength(.1))
-        .force('y', forceY(0).strength(.1))
+        .force('x', forceX(0).strength(.05))
+        .force('y', forceY(0).strength(.06))
         .force('repel', forceManyBody().strength(-50))
         .on('tick', this.onSimulationUpdate_.bind(this));
 

--- a/src/renderers/simple.js
+++ b/src/renderers/simple.js
@@ -223,7 +223,7 @@ export class SimpleRenderer extends Renderer {
    * @private
    */
   updateNodes_(graph) {
-    graph.getNodes().forEach((node) => {
+    graph.forEachNode((node) => {
       const container = node.getContainer();
       container.setTransform(node.x, node.y);
 

--- a/src/renderers/simple.js
+++ b/src/renderers/simple.js
@@ -178,8 +178,9 @@ export class SimpleRenderer extends Renderer {
       }
       if (!this.nodeWatchers_.has(node)) {
         const hoverStart = this.createHoverStart_(node);
-        this.nodeWatchers_.set(node, new Map().set('mouseover', hoverStart));
-        this.nodeWatchers_.set(node, new Map().set('mousedown', hoverStart));
+        this.nodeWatchers_.set(node, new Map()
+            .set('mouseover', hoverStart)
+            .set('mousedown', hoverStart));
         node.getContainer().on('mouseover', hoverStart);
         node.getContainer().on('mousedown', hoverStart);
       }
@@ -261,7 +262,7 @@ export class SimpleRenderer extends Renderer {
    * @private
    */
   updateEdges_(graph) {
-    graph.getEdges().forEach((edge) => {
+    graph.forEachEdge((edge) => {
       const sourceNode = graph.getNode(edge.getSourceId());
       const targetNode = graph.getNode(edge.getTargetId());
 


### PR DESCRIPTION
### Description

Improves the efficiency of rendering by adding caching.

Also lowers the centering force because my graph was starting to get crowded.

### Testing

I did lots of logging to figure out what was causing the bottle necks. 
[Profile-run.zip](https://github.com/BeksOmega/obsidian-better-graph-view/files/5826857/Profile-run.zip) <- That is a zip of profiles that you can view in the chrome console.

Also tested on my main vault and everything seems to work well.

And I did a thorough read to make sure there were no regressions (hopefully).

